### PR TITLE
Include changes for AI and copyright protected content use cases

### DIFF
--- a/Appendix3.md
+++ b/Appendix3.md
@@ -1,0 +1,3 @@
+# Appendix 3 – Artificial Intelligence
+
+To be completed.

--- a/CSP.md
+++ b/CSP.md
@@ -5,44 +5,44 @@ Policy Level 2](https://www.w3.org/TR/CSP2/#directive-style-src)*.*
 
 ### 7.17
 
-The *tui-src* \*directive restricts which data storage key Terms Unique
-Identifier (TUI) values the user may receive values or content for. The syntax
+The *tdl-src* \*directive restricts which data storage key Terms Unique
+Identifier (TDL) values the user may receive values or content for. The syntax
 for the name and value of the directive are described by the following ABNF
 grammar:
 
-directive-name = "tui-src"
+directive-name = "tdl-src"
 
 directive-value = [source-list](https://www.w3.org/TR/CSP2/#source_list)
 
-The term *allowed tui sources* refers to the result of [parsing the tui-src
+The term *allowed tdl sources* refers to the result of [parsing the tdl-src
 directive’s value as a source
 list](https://www.w3.org/TR/CSP2/#parse-a-source-list) if the policy contains an
-explicit tui-src.
+explicit tdl-src.
 
-Whenever the user agent processes any content, if none of the [allowed tui
+Whenever the user agent processes any content, if none of the [allowed tdl
 sources](https://www.w3.org/TR/CSP2/#allowed-style-sources)
-[match](https://www.w3.org/TR/CSP2/#match-a-source-list) the TUI values agreed
+[match](https://www.w3.org/TR/CSP2/#match-a-source-list) the TDL values agreed
 to by the user of the user agent then the content will not be retrieved by the
-user agent. If no allowed tui sources are provided then this restriction does
+user agent. If no allowed tdl sources are provided then this restriction does
 not apply.
 
 Whenever the user agent processes a storage read request using a key, if none of
-the [allowed tui sources](https://www.w3.org/TR/CSP2/#allowed-style-sources)
-[match](https://www.w3.org/TR/CSP2/#match-a-source-list) the TUI values provided
+the [allowed tdl sources](https://www.w3.org/TR/CSP2/#allowed-style-sources)
+[match](https://www.w3.org/TR/CSP2/#match-a-source-list) the TDL values provided
 with the storage key when the write operation for that key was performed, the
 user agent MUST not return the associated value and [report a
 violation](https://www.w3.org/TR/CSP2/#report-a-violation).
 
 For example, if the domain `example.com` performed a write storage operation
-with the TUI label `https://ex.io/eu-meta-v3.html` and key `example-3p` and then
+with the TDL label `https://ex.io/eu-meta-v3.html` and key `example-3p` and then
 domain example operating as a resource for domain `publisher.com` attempted to
-read key `example-3p` from storage and domain `publisher.com`’s CSP *tui-src*
+read key `example-3p` from storage and domain `publisher.com`’s CSP *tdl-src*
 list did not include `https://ex.io/eu-meta-v3.html` then the read operation
 would not return a value and the user agent would report the CSP violation.
 
 For example, if the domain `publisher.com` performed a write storage operation
-with the TUI label `https://ex.io/eu-meta-v2.html` and key `example-1p `and then
-tried to read the key `example-1p` without a CSP tui-src list being provided to
+with the TDL label `https://ex.io/eu-meta-v2.html` and key `example-1p `and then
+tried to read the key `example-1p` without a CSP tdl-src list being provided to
 the user agent that included the source` https://ex.io/eu-meta-v2.html` then the
 read operation would not return a value and the user agent would report the CSP
 violation.
@@ -52,12 +52,12 @@ resource `example.com` and the resource `example.com` performs a storage
 operation for the key `example-3p` and label `https://ex.io/eu-meta-v3.html`
 then `example.com` when included as a resource in the different address bar
 visible domain `publisherB.com` would be allowed to read the value for key
-`example-3p` only if `publisherB.com`’s and `example.com`’s CSP tui-src lists
+`example-3p` only if `publisherB.com`’s and `example.com`’s CSP tdl-src lists
 both include `https://ex.io/eu-meta-v3.html`. If `publisherB.com` does not have
-a CSP with a tui-src list including `https://ex.io/eu-meta-v3.html`then the read
+a CSP with a tdl-src list including `https://ex.io/eu-meta-v3.html`then the read
 operation by `example.com` would result in the user agent reporting the CSP
 violation.
 
-Note: This section refers only to the aspects of Terms Unique Identifiers that
-relate to CSP and does not include the wider use of Terms Unique Identifiers
+Note: This section refers only to the aspects of Terms Document Locators that
+relate to CSP and does not include the wider use of Terms Document Locators
 which are defined in [the proposal](Proposal.md).

--- a/CSP.md
+++ b/CSP.md
@@ -1,56 +1,63 @@
 # W3C - Content Security Policy 2
 
-*The following text will be included as a PR to added to [Content Security
-Policy Level 2](https://www.w3.org/TR/CSP2/#directive-style-src).*
+*The following text will be included as a PR to added to* [Content Security
+Policy Level 2](https://www.w3.org/TR/CSP2/#directive-style-src)*.*
 
 ### 7.17
 
-The *lbu-src* *directive restricts which data storage key Legal Basis URLs
-(LBU) labels the user may receive values for. The syntax for the name and value
-of the directive are described by the following ABNF grammar:
+The *tui-src* \*directive restricts which data storage key Terms Unique
+Identifier (TUI) values the user may receive values or content for. The syntax
+for the name and value of the directive are described by the following ABNF
+grammar:
 
-directive-name = "lbu-src"
+directive-name = "tui-src"
 
 directive-value = [source-list](https://www.w3.org/TR/CSP2/#source_list)
 
-The term *allowed lbu sources* refers to the result of 
-[parsing the lbu-src directive’s value as a source list](https://www.w3.org/TR/CSP2/#parse-a-source-list)
-if the policy contains an explicit lbu-src.
+The term *allowed tui sources* refers to the result of [parsing the tui-src
+directive’s value as a source
+list](https://www.w3.org/TR/CSP2/#parse-a-source-list) if the policy contains an
+explicit tui-src.
 
-Whenever the user agent processes a storage read request using a key, if none
-of the
-[allowed lbu sources](https://www.w3.org/TR/CSP2/#allowed-style-sources)
-[match](https://www.w3.org/TR/CSP2/#match-a-source-list) the LBU label
-provided with the storage key when the write operation for that key was
-performed, the user agent MUST not return the associated value and
-[report a violation](https://www.w3.org/TR/CSP2/#report-a-violation).
+Whenever the user agent processes any content, if none of the [allowed tui
+sources](https://www.w3.org/TR/CSP2/#allowed-style-sources)
+[match](https://www.w3.org/TR/CSP2/#match-a-source-list) the TUI values agreed
+to by the user of the user agent then the content will not be retrieved by the
+user agent. If no allowed tui sources are provided then this restriction does
+not apply.
+
+Whenever the user agent processes a storage read request using a key, if none of
+the [allowed tui sources](https://www.w3.org/TR/CSP2/#allowed-style-sources)
+[match](https://www.w3.org/TR/CSP2/#match-a-source-list) the TUI values provided
+with the storage key when the write operation for that key was performed, the
+user agent MUST not return the associated value and [report a
+violation](https://www.w3.org/TR/CSP2/#report-a-violation).
 
 For example, if the domain `example.com` performed a write storage operation
-with the LBU label `https://ex.io/eu-meta-v3.html` and key `example-3p`
-and then domain example operating as a resource for domain `publisher.com`
-attempted to read key `example-3p` from storage and domain `publisher.com`’s
-CSP *lbu-src* list did not include `https://ex.io/eu-meta-v3.html` then
-the read operation would not return a value and the user agent would report the
-CSP violation.
+with the TUI label `https://ex.io/eu-meta-v3.html` and key `example-3p` and then
+domain example operating as a resource for domain `publisher.com` attempted to
+read key `example-3p` from storage and domain `publisher.com`’s CSP *tui-src*
+list did not include `https://ex.io/eu-meta-v3.html` then the read operation
+would not return a value and the user agent would report the CSP violation.
 
-For example, if the domain `publisher.com` performed a write storage
-operation with the LBU label ` https://ex.io/eu-meta-v2.html` and key
-`example-1p `and then tried to read the key `example-1p ` without a CSP
-lbu-src list being provided to the user agent  that included the source `
-https://ex.io/eu-meta-v2.html` then the read operation would not return a value
-and the user agent would report the CSP violation.
+For example, if the domain `publisher.com` performed a write storage operation
+with the TUI label `https://ex.io/eu-meta-v2.html` and key `example-1p `and then
+tried to read the key `example-1p` without a CSP tui-src list being provided to
+the user agent that included the source` https://ex.io/eu-meta-v2.html` then the
+read operation would not return a value and the user agent would report the CSP
+violation.
 
 For example, if the address bar visible domain `publisherA.com` includes the
 resource `example.com` and the resource `example.com` performs a storage
 operation for the key `example-3p` and label `https://ex.io/eu-meta-v3.html`
 then `example.com` when included as a resource in the different address bar
 visible domain `publisherB.com` would be allowed to read the value for key
-`example-3p` only if `publisherB.com`’s and `example.com`’s CSP lbu-src
-lists both include `https://ex.io/eu-meta-v3.html`. If `publisherB.com` does
-not have a CSP with a lbu-src list including
-`https://ex.io/eu-meta-v3.html`then the read operation by `example.com`
-would result in the user agent reporting the CSP violation.
+`example-3p` only if `publisherB.com`’s and `example.com`’s CSP tui-src lists
+both include `https://ex.io/eu-meta-v3.html`. If `publisherB.com` does not have
+a CSP with a tui-src list including `https://ex.io/eu-meta-v3.html`then the read
+operation by `example.com` would result in the user agent reporting the CSP
+violation.
 
-Note: This section refers only to the aspects of Legal Basis Labels that relate
-to CSP and does not include the wider use of Legal Basis Labels which are
-defined in [the proposal](Proposal.md).
+Note: This section refers only to the aspects of Terms Unique Identifiers that
+relate to CSP and does not include the wider use of Terms Unique Identifiers
+which are defined in [the proposal](Proposal.md).

--- a/FAQs.md
+++ b/FAQs.md
@@ -1,0 +1,192 @@
+# Frequently Asked Questions
+
+The following common questions have been asked during briefing sessions.
+
+Most of the questions relate to the likely use of the proposal. As such the
+answers are those that are considered likely uses of the technical change. There
+are likely many other innovations and alternative approaches that will emerge in
+practice. The answers should be considered for guidance and inspiration.
+
+The questions and answers are divided between those that are general, artificial
+intelligence, advertising, and web browser specific specific.
+
+Contents
+
+[Frequently Asked Questions](#frequently-asked-questions)
+
+[General](#general)
+
+[Who will author data label documents?](#who-will-author-data-label-documents)
+
+[What if there are multiple data label documents for the same type of
+data?](#what-if-there-are-multiple-data-label-documents-for-the-same-type-of-data)
+
+[How will data labels be applied to existing
+contracts?](#how-will-data-labels-be-applied-to-existing-contracts)
+
+[Who will monitor data label documents?](#who-will-monitor-data-label-documents)
+
+[Are data labels machine readable?](#are-data-labels-machine-readable)
+
+[Artificial Intelligence](#advertising)
+
+[Do data labels work with robots.txt?](#do-data-labels-work-with-robotstxt)
+
+[Do data labels work with HTML?](#do-data-labels-work-with-html)
+
+[Do data labels work for machine only data
+types?](#do-data-labels-work-for-machine-only-data-types)
+
+[Web Browsers](#web-browsers)
+
+[How does the proposal protect publisher’s
+data?](#how-does-the-proposal-protect-publishers-data)
+
+[Can domains lie about the data label documents they are bound
+by?](#can-domains-lie-about-the-data-label-documents-they-are-bound-by)
+
+[What if a third party lies about the data label documents they
+support?](#what-if-a-third-party-lies-about-the-data-label-documents-they-support)
+
+### General
+
+### Who will author data label documents?
+
+The answer will be a matter for individual participants. However if past
+precedent is a guide then trade bodies will likely seek to create terms
+documents for use in data labels for common use cases.
+
+Where data protection is the concern then lawyers and Data Protection Officers
+will be involved.
+
+When copyright protected content is licensed commercial professionals and IP
+lawyers will likely create documents. Importantly engineers will get out of the
+way.
+
+### What if there are multiple data label documents for the same type of data?
+
+This will create competition among data label documents and should be considered
+a good outcome. For example; some documents might contain provisions that
+require attestation of the recipients computer code and platform, whilst another
+document might not. Much like open source licenses, it will be for individual
+organizations to decide which data label documents to work with.
+
+### How will data labels be applied to existing contracts?
+
+Existing contracts can be modified to reference data label documents. When
+common clauses in contracts are sufficiently defined in data label documents the
+complexity of contract administration will likely reduce.
+
+### Who will monitor data label documents?
+
+Just like in other industries there are likely to be different bodies with
+different considerations reviewing data labels. Civil society organizations
+might review common data labels and score them by different criteria. Web
+browser vendors might add an icon to the address bar of the web browser that
+enables users to choose a data label rating service and display the aggregate
+score associated with all data labels used to display a web page. Web browser
+vendors might then offer a setting that warns the user if the aggregate score
+falls outside a preset threshold.
+
+### Are data labels machine readable?
+
+Yes. Each TUI is a unique identifier. There will likely be TUI documents for
+specific use cases and data types. Each organization will decide which TUI to
+accept or reject and how to handle TUI values that they have not yet
+categorized. When their agents encounter these documents they will know how to
+respond based on these decisions.
+
+A TUI document might combine via reference many other TUI values to avoid
+duplication.
+
+### Is there a data overhead associated with data labels?
+
+The data label will typically consist of a single short URL and a short field
+indicator. As such it is no larger than any other type of meta data that
+accompanies digital activities including HTTP headers for support encodings,
+user agent information, or referrer information. Given the value data labels
+provide the authors consider the trade off well worth it.
+
+Any additional reporting requirements will be a matter for individual data
+labels where it is expected that the market will gravitate towards trade offs
+that are justifiable and therefore become widely adopted. An advantage of data
+labels is that the market will decide for specific use cases based on the risk
+and value of the data.
+
+## Advertising
+
+### How is are data labels enforced via OpenRTB?
+
+The provision of a data label field and the requirement to retain the data label
+with the associated data is part of the proposal. Should a party be discovered
+to have breached the terms of the sender, or any sender upstream, then it will
+be a matter for the authors of the terms documents to decide how to sanction
+such breaches. Options might include reporting the breach publicly or ceasing to
+do business with the breaching party.
+
+## Artificial Intelligence
+
+### Do data labels work with robots.txt?
+
+Yes. A new value is added to the robots.txt specification that indicates the
+terms under which the subsequent Allow lines apply.
+
+### Do data labels work with HTML?
+
+Yes. Any HTML element can have a tui attribute added to it indicating the terms
+associated with the content contained within the tag. Therefore a web page might
+contain content that is made available under different terms. For example; the
+summary might be available for any use, but the body of the page might require
+different terms.
+
+### Do data labels work for machine only data types?
+
+Yes. Any data schema can be modified to support the data labels extension which
+is merely an array of TUI values provided as strings.
+
+### How do data labels work with payment models?
+
+Data labels are component of payment models and measurement mechanisms.
+
+The terms document might include reference to payment models which will be a
+matter for the parties to decide how to implement between themselves. Data
+labels will become an important component of content payment models. The sooner
+they are adopted the sooner those working on payment models will have a
+foundational component upon which to build.
+
+## Web Browsers
+
+### How does the proposal protect publisher’s data?
+
+The Content Security Policy (CSP) will advertise to the web browser the TUI
+documents that the domain operator is bound by. When data is retrieved from the
+web browser via cookies, or in the future other upgraded storage, then the CSP
+of the publisher, the TUI applied to the cookie when set, and any third-parties
+included on the page must all contain the same TUI value for the data to be
+retrieved. Thus publishers will be able to control which third-parties can
+access data.
+
+### Can domains lie about the data label documents they are bound by?
+
+Yes. Whilst there is free will in the world people will lie. However, the
+proposal when widely adopted will significantly increase the probability of bad
+actors being caught and bought to justice.
+
+### What if a third party lies about the data label documents they support?
+
+It is likely that those using data labels in commercial contracts will modify
+existing audit and reporting provisions to include TUI monitoring and ensure
+there is a requirement for any onward sharing of data to be bound by the same
+data label document.
+
+All storage retrieval requests under the proposal will require the CSP to
+advertise support for the necessary TUI documents.
+
+Therefore when a publishers or other party observes other parties interacting
+with the data they can ask their supply chain to report the parties that have
+downstream commercial contracts and the TUIs involved.
+
+Where a party bound by the data label document has not complied with the
+provision to bind further parties to the same data label document this will
+become apparent. It will be for the individual parties involved to determine how
+to remedy the situation.

--- a/FAQs.md
+++ b/FAQs.md
@@ -8,47 +8,9 @@ are likely many other innovations and alternative approaches that will emerge in
 practice. The answers should be considered for guidance and inspiration.
 
 The questions and answers are divided between those that are general, artificial
-intelligence, advertising, and web browser specific specific.
+intelligence, advertising, and web browser specific.
 
-Contents
-
-[Frequently Asked Questions](#frequently-asked-questions)
-
-[General](#general)
-
-[Who will author data label documents?](#who-will-author-data-label-documents)
-
-[What if there are multiple data label documents for the same type of
-data?](#what-if-there-are-multiple-data-label-documents-for-the-same-type-of-data)
-
-[How will data labels be applied to existing
-contracts?](#how-will-data-labels-be-applied-to-existing-contracts)
-
-[Who will monitor data label documents?](#who-will-monitor-data-label-documents)
-
-[Are data labels machine readable?](#are-data-labels-machine-readable)
-
-[Artificial Intelligence](#advertising)
-
-[Do data labels work with robots.txt?](#do-data-labels-work-with-robotstxt)
-
-[Do data labels work with HTML?](#do-data-labels-work-with-html)
-
-[Do data labels work for machine only data
-types?](#do-data-labels-work-for-machine-only-data-types)
-
-[Web Browsers](#web-browsers)
-
-[How does the proposal protect publisher’s
-data?](#how-does-the-proposal-protect-publishers-data)
-
-[Can domains lie about the data label documents they are bound
-by?](#can-domains-lie-about-the-data-label-documents-they-are-bound-by)
-
-[What if a third party lies about the data label documents they
-support?](#what-if-a-third-party-lies-about-the-data-label-documents-they-support)
-
-### General
+## General
 
 ### Who will author data label documents?
 
@@ -90,13 +52,13 @@ falls outside a preset threshold.
 
 ### Are data labels machine readable?
 
-Yes. Each TUI is a unique identifier. There will likely be TUI documents for
-specific use cases and data types. Each organization will decide which TUI to
-accept or reject and how to handle TUI values that they have not yet
+Yes. Each TDL is a unique identifier. There will likely be TDL documents for
+specific use cases and data types. Each organization will decide which TDL to
+accept or reject and how to handle TDL values that they have not yet
 categorized. When their agents encounter these documents they will know how to
 respond based on these decisions.
 
-A TUI document might combine via reference many other TUI values to avoid
+A TDL document might combine via reference many other TDL values to avoid
 duplication.
 
 ### Is there a data overhead associated with data labels?
@@ -133,7 +95,7 @@ terms under which the subsequent Allow lines apply.
 
 ### Do data labels work with HTML?
 
-Yes. Any HTML element can have a tui attribute added to it indicating the terms
+Yes. Any HTML element can have a tdl attribute added to it indicating the terms
 associated with the content contained within the tag. Therefore a web page might
 contain content that is made available under different terms. For example; the
 summary might be available for any use, but the body of the page might require
@@ -142,7 +104,7 @@ different terms.
 ### Do data labels work for machine only data types?
 
 Yes. Any data schema can be modified to support the data labels extension which
-is merely an array of TUI values provided as strings.
+is merely an array of TDL values provided as strings.
 
 ### How do data labels work with payment models?
 
@@ -158,11 +120,11 @@ foundational component upon which to build.
 
 ### How does the proposal protect publisher’s data?
 
-The Content Security Policy (CSP) will advertise to the web browser the TUI
+The Content Security Policy (CSP) will advertise to the web browser the TDL
 documents that the domain operator is bound by. When data is retrieved from the
 web browser via cookies, or in the future other upgraded storage, then the CSP
-of the publisher, the TUI applied to the cookie when set, and any third-parties
-included on the page must all contain the same TUI value for the data to be
+of the publisher, the TDL applied to the cookie when set, and any third-parties
+included on the page must all contain the same TDL value for the data to be
 retrieved. Thus publishers will be able to control which third-parties can
 access data.
 
@@ -175,16 +137,16 @@ actors being caught and bought to justice.
 ### What if a third party lies about the data label documents they support?
 
 It is likely that those using data labels in commercial contracts will modify
-existing audit and reporting provisions to include TUI monitoring and ensure
+existing audit and reporting provisions to include TDL monitoring and ensure
 there is a requirement for any onward sharing of data to be bound by the same
 data label document.
 
 All storage retrieval requests under the proposal will require the CSP to
-advertise support for the necessary TUI documents.
+advertise support for the necessary TDL documents.
 
 Therefore when a publishers or other party observes other parties interacting
 with the data they can ask their supply chain to report the parties that have
-downstream commercial contracts and the TUIs involved.
+downstream commercial contracts and the TDLs involved.
 
 Where a party bound by the data label document has not complied with the
 provision to bind further parties to the same data label document this will

--- a/IETF-HTTP.md
+++ b/IETF-HTTP.md
@@ -5,35 +5,35 @@ Engineering Task Force’s Cookies: HTTP State Management
 Mechanism](https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/)
 *document. The precise chapters to include this text are to be determined.*
 
-## Terms Unique Identifier Attribute
+## Terms Document Locator Attribute
 
-A new attribute titled `tui` or `terms-unique-identifier` will be added to the
+A new attribute titled `tdl` or `terms-document-locator` will be added to the
 allowed attributes of the `Set-Cookie` syntax.
 
-The purpose of the `tui` label is to provide an immutable document that contains
+The purpose of the `tdl` label is to provide an immutable document that contains
 the legal basis used to collect, store, use, and restrict the associated
 `cookie-value` such that storage retrieval operations can utilize modifications
 to Content Security Policy to determine if a storage read operation should be
 allowed or denied.
 
-The value provided as the `tui` attribute must conform to the URI schema. (RFC
+The value provided as the `tdl` attribute must conform to the URI schema. (RFC
 3986 which defined URI is already an informative reference). Any value that does
 not conform to URI will be rejected and the operation will proceed as if the
-`tui` attribute had not been provided.
+`tdl` attribute had not been provided.
 
-`Set-Cookie` operations will store the `tui` value with the cookie-name and
+`Set-Cookie` operations will store the `tdl` value with the cookie-name and
 cookie-value.
 
-The following is an example of Set-Cookie operation that includes a TUI value.
+The following is an example of Set-Cookie operation that includes a TDL value.
 
 ```text
-Set-Cookie: SID=31d4d96e407aad42; TUI=https://ex.io/eu-ads-v1.html
+Set-Cookie: SID=31d4d96e407aad42; TDL=https://ex.io/eu-ads-v1.html
 ```
 
-TUI documents must be immutable and never change once published. They SHOULD
+TDL documents must be immutable and never change once published. They SHOULD
 contain a version component in their construction.
 
-If the implementor detects a change to the content of the TUI document which
+If the implementor detects a change to the content of the TDL document which
 does not relate to user preferences such as language, then the implementor
-SHOULD consider the TUI value to be unusable and reject it. This behavior
-encourages authors of TUI documents to exercise strict version controls.
+SHOULD consider the TDL value to be unusable and reject it. This behavior
+encourages authors of TDL documents to exercise strict version controls.

--- a/IETF-HTTP.md
+++ b/IETF-HTTP.md
@@ -1,39 +1,39 @@
 # IETF - HTTP Working Group
 
-*The following text will be included as a change request to the [Internet
-Engineering Task Force’s Cookies: HTTP State Management Mechanism](https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/)
-document. The precise chapters to include this text are to be determined.*
+*The following text will be included as a change request to the* [Internet
+Engineering Task Force’s Cookies: HTTP State Management
+Mechanism](https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/)
+*document. The precise chapters to include this text are to be determined.*
 
-## Legal Basis Attribute
+## Terms Unique Identifier Attribute
 
-A new attribute titled `lbu` or `legal-basis-uri` will be added to the
+A new attribute titled `tui` or `terms-unique-identifier` will be added to the
 allowed attributes of the `Set-Cookie` syntax.
 
-The purpose of the `lbu` label is to provide an immutable document that
-contains the legal basis used to collect, store, use, and restrict the
-associated `cookie-value` such that storage retrieval operations can utilize
-modifications to Content Security Policy to determine if a storage read
-operation should be allowed or denied.
+The purpose of the `tui` label is to provide an immutable document that contains
+the legal basis used to collect, store, use, and restrict the associated
+`cookie-value` such that storage retrieval operations can utilize modifications
+to Content Security Policy to determine if a storage read operation should be
+allowed or denied.
 
-The value provided as the `lbu` attribute must conform to the URI schema.
-(RFC 3986 which defined URI is already an informative reference). Any value that
-does not conform to URI will be rejected and the operation will proceed as if
-the `lbu` attribute had not been provided.
+The value provided as the `tui` attribute must conform to the URI schema. (RFC
+3986 which defined URI is already an informative reference). Any value that does
+not conform to URI will be rejected and the operation will proceed as if the
+`tui` attribute had not been provided.
 
-`Set-Cookie` operations will store the `lbu` value with the cookie-name and
+`Set-Cookie` operations will store the `tui` value with the cookie-name and
 cookie-value.
 
-The following is an example of Set-Cookie operation that includes an LBU
-value.
+The following is an example of Set-Cookie operation that includes a TUI value.
 
 ```text
-Set-Cookie: SID=31d4d96e407aad42; LBU=https://ex.io/eu-ads-v1.html
+Set-Cookie: SID=31d4d96e407aad42; TUI=https://ex.io/eu-ads-v1.html
 ```
 
-LBU documents must be immutable and never change once published. They SHOULD
+TUI documents must be immutable and never change once published. They SHOULD
 contain a version component in their construction.
 
-If the implementor detects a change to the content of the LBU document which
+If the implementor detects a change to the content of the TUI document which
 does not relate to user preferences such as language, then the implementor
-SHOULD consider the LBU value to be unusable and reject it. This behavior
-encourages authors of LBU documents to exercise strict version controls.
+SHOULD consider the TUI value to be unusable and reject it. This behavior
+encourages authors of TUI documents to exercise strict version controls.

--- a/IETF-Robots.md
+++ b/IETF-Robots.md
@@ -1,0 +1,38 @@
+# IETF
+
+*The following text will be included as a change request to the* [*Internet
+Engineering Task Force’s Robots Exclusion
+Protocol*](https://www.rfc-editor.org/rfc/rfc9309.html) *document. The precise
+chapters to include this text are to be determined.*
+
+## Terms Unique Identifiers (TUI) Line
+
+A new line titled `tui` or `terms-unique-identifier` will be added between
+User-Agent and Allow/Disallow lines.
+
+The purpose of the `tui` label is to provide a reference to an immutable
+document that contains the terms under which a crawler can collect, store, use,
+and restrict the associated `allow `content such that retrieval operations can
+only commence once acceptance to those terms has been verified by the crawler
+with its operator.
+
+The value provided as the `tui` attribute must conform to the URI schema. (RFC
+3986 which defined URI is already an informative reference). Any value that does
+not conform to URI will be rejected and the operation will proceed as if the
+`tui` attribute had not been provided.
+
+The following is an example of a robots.txt that includes a `tui` value.
+
+```text
+User-Agent: *
+TUI: https://www.facebook.com/legal/automated_data_collection_terms
+Allow: /
+```
+
+TUI documents MUST be immutable and never change once published. They SHOULD
+contain a version component in their construction.
+
+If the implementor detects a change to the content of the TUI document which
+does not relate to user preferences such as language, then the implementor
+SHOULD consider the TUI value to be unusable and reject it. This behavior
+encourages authors of TUI documents to exercise strict version controls.

--- a/IETF-Robots.md
+++ b/IETF-Robots.md
@@ -5,34 +5,34 @@ Engineering Task Force’s Robots Exclusion
 Protocol*](https://www.rfc-editor.org/rfc/rfc9309.html) *document. The precise
 chapters to include this text are to be determined.*
 
-## Terms Unique Identifiers (TUI) Line
+## Terms Document Locators (TDL) Line
 
-A new line titled `tui` or `terms-unique-identifier` will be added between
+A new line titled `tdl` or `terms-document-locator` will be added between
 User-Agent and Allow/Disallow lines.
 
-The purpose of the `tui` label is to provide a reference to an immutable
+The purpose of the `tdl` label is to provide a reference to an immutable
 document that contains the terms under which a crawler can collect, store, use,
 and restrict the associated `allow `content such that retrieval operations can
 only commence once acceptance to those terms has been verified by the crawler
 with its operator.
 
-The value provided as the `tui` attribute must conform to the URI schema. (RFC
+The value provided as the `tdl` attribute must conform to the URI schema. (RFC
 3986 which defined URI is already an informative reference). Any value that does
 not conform to URI will be rejected and the operation will proceed as if the
-`tui` attribute had not been provided.
+`tdl` attribute had not been provided.
 
-The following is an example of a robots.txt that includes a `tui` value.
+The following is an example of a robots.txt that includes a `tdl` value.
 
 ```text
 User-Agent: *
-TUI: https://www.facebook.com/legal/automated_data_collection_terms
+TDL: https://www.facebook.com/legal/automated_data_collection_terms
 Allow: /
 ```
 
-TUI documents MUST be immutable and never change once published. They SHOULD
+TDL documents MUST be immutable and never change once published. They SHOULD
 contain a version component in their construction.
 
-If the implementor detects a change to the content of the TUI document which
+If the implementor detects a change to the content of the TDL document which
 does not relate to user preferences such as language, then the implementor
-SHOULD consider the TUI value to be unusable and reject it. This behavior
-encourages authors of TUI documents to exercise strict version controls.
+SHOULD consider the TDL value to be unusable and reject it. This behavior
+encourages authors of TDL documents to exercise strict version controls.

--- a/OpenRTB.md
+++ b/OpenRTB.md
@@ -1,31 +1,32 @@
 # IAB Tech Lab - Open RTB
 
-*The following text will be included as a change request to the [Open RTB
-specification 2.6](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectmodel) Object Model section.*
+*The following text will be included as a change request to the* [Open RTB
+specification
+2.6](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectmodel)
+*Object Model section.*
 
 ## Labelling
 
-OpenRTB is a hierarchy where there are many nodes that might relate to
-different data types. The following considers applying labels to this
-hierarchy.
+OpenRTB is a hierarchy where there are many nodes that might relate to different
+data types. The following considers applying labels to this hierarchy.
 
-Any node, including the root node, can have a member called `lbu` which
-provides an array of URIs that are labels for the legal bases relied upon by the
-creator of the document to provide the basis used to collection, share, and use
-the associated data at that node and all descendant nodes of the model.
+Any node, including the root node, can have a member called `tui` which provides
+an array of URIs that are labels for the legal bases relied upon by the creator
+of the document to provide the basis used to collection, share, and use the
+associated data at that node and all descendant nodes of the model.
 
-Each entry in the `lbu` array labels MUST point to a human readable document
+Each entry in the `tui` array labels MUST point to a human readable document
 that describes the legal basis associated with the data at the node.
 
-LBU documents must be immutable and never change once published. They should
+TUI documents must be immutable and never change once published. They should
 therefore contain a version component in their construction.
 
-The implementor detects a change to the content of the LBU document which does
+The implementor detects a change to the content of the TUI document which does
 not relate to user preferences such as language, then the implementor SHOULD
-consider the LBU value to be unusable and reject it. This behavior encourages
-authors of LBU documents to exercise strict version controls.
+consider the TUI value to be unusable and reject it. This behavior encourages
+authors of TUI documents to exercise strict version controls.
 
-The root level of a hierarchy SHOULD contain an `lbu` field. Where it doesn’t
+The root level of a hierarchy SHOULD contain a `tui` field. Where it doesn’t
 then the recipient can’t assume anything and MUST operate as if no legal basis
 is known. That might mean in practice they reject the entire message. That will
 be a choice for each individual recipient and will likely change as the
@@ -33,20 +34,20 @@ requestor implementations mature.
 
 ### *Evaluation*
 
-The `lbu` array entries MUST apply to all descendent nodes.
+The `tui` array entries MUST apply to all descendent nodes.
 
-Where a descendant node contains an `lbu` field the ancestor `lbu` entry
-is **replaced**. This is needed to enable a general LBU entry and the
-subsequent signaling of exclusions subject to different LBUs.
+Where a descendant node contains an `tui` field the ancestor `tui` entry is
+**replaced**. This is needed to enable a general TUI entry and the subsequent
+signaling of exclusions subject to different TUIs.
 
-For example; a root node containing an `lbu` field and one entry would apply
-to all data in the data structure. See the following example with highlighting
+For example; a root node containing an `tui` field and one entry would apply to
+all data in the data structure. See the following example with highlighting
 added.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
-    "lbu": [ "https://ex.io/eu-ads-v1.html" ],
+    "tui": [ "https://ex.io/eu-ads-v1.html" ],
     "device": {
         "make": "Samsung",
         "model": "SCH-I535",
@@ -63,15 +64,15 @@ added.
 }
 ```
 
-For example; a leaf node containing an `lbu` field with a different value to
-its ancestor would signal that the leaf node alone was subject to the subsequent
+For example; a leaf node containing an `tui` field with a different value to its
+ancestor would signal that the leaf node alone was subject to the subsequent
 legal basis. The following example modifies the previous example by including
-different `lbu` labels for the `device` and `user` nodes.
+different `tui` labels for the `device` and `user` nodes.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
-    "lbu": [ "https://ex.io/eu-ads-v1.html" ],
+    "tui": [ "https://ex.io/eu-ads-v1.html" ],
     "device": {
         "make": "Samsung",
         "model": "SCH-I535",
@@ -81,11 +82,11 @@ different `lbu` labels for the `device` and `user` nodes.
         "geo": {
             "country": "USA"
         }
-        "lbu": [ "https://ex.io/eu-meta-v3.html" ],
+        "tui": [ "https://ex.io/eu-meta-v3.html" ],
     },
     "user": {
         "id": "bd5adc55dcbab4bf090604df4f543d90b09f0c88",
-        "lbu": [ "https://ex.io/eu-ids-d-v2.html" ],
+        "tui": [ "https://ex.io/eu-ids-d-v2.html" ],
     }
 }
 ```
@@ -93,20 +94,20 @@ different `lbu` labels for the `device` and `user` nodes.
 ### Filtering
 
 Recipients will create masks of the data model’s tree structure containing only
-`lbu` array entries that list the entries that they wish to include or reject
+`tui` array entries that list the entries that they wish to include or reject
 for specific purposes.
 
 For example; if a recipient wished to create a copy of the source data
-containing only LBUs that were acceptable to them for onward sharing they would
-apply a mask containing their allowed LBUs for onwards sharing.
+containing only TUIs that were acceptable to them for onward sharing they would
+apply a mask containing their allowed TUIs for onwards sharing.
 
 Stripping the `user` node would be achieved in the following example by
-rejecting the LBU value `https://ex.io/eu-ids-d-v2.html`.
+rejecting the TUI value `https://ex.io/eu-ids-d-v2.html`.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
-    "lbu": [ "https://ex.io/eu-ads-v1.html" ],
+    "tui": [ "https://ex.io/eu-ads-v1.html" ],
     "device": {
         "make": "Samsung",
         "model": "SCH-I535",
@@ -116,11 +117,11 @@ rejecting the LBU value `https://ex.io/eu-ids-d-v2.html`.
         "geo": {
             "country": "USA"
         }
-        "lbu": [ "https://ex.io/eu-meta-v3.html" ],
+        "tui": [ "https://ex.io/eu-meta-v3.html" ],
     },
     "user": {
         "id": "bd5adc55dcbab4bf090604df4f543d90b09f0c88",
-        "lbu": [ "https://ex.io/eu-ids-d-v2.html" ],
+        "tui": [ "https://ex.io/eu-ids-d-v2.html" ],
     }
 }
 ```

--- a/OpenRTB.md
+++ b/OpenRTB.md
@@ -10,23 +10,23 @@ specification
 OpenRTB is a hierarchy where there are many nodes that might relate to different
 data types. The following considers applying labels to this hierarchy.
 
-Any node, including the root node, can have a member called `tui` which provides
+Any node, including the root node, can have a member called `tdl` which provides
 an array of URIs that are labels for the legal bases relied upon by the creator
 of the document to provide the basis used to collection, share, and use the
 associated data at that node and all descendant nodes of the model.
 
-Each entry in the `tui` array labels MUST point to a human readable document
+Each entry in the `tdl` array labels MUST point to a human readable document
 that describes the legal basis associated with the data at the node.
 
-TUI documents must be immutable and never change once published. They should
+TDL documents must be immutable and never change once published. They should
 therefore contain a version component in their construction.
 
-The implementor detects a change to the content of the TUI document which does
+The implementor detects a change to the content of the TDL document which does
 not relate to user preferences such as language, then the implementor SHOULD
-consider the TUI value to be unusable and reject it. This behavior encourages
-authors of TUI documents to exercise strict version controls.
+consider the TDL value to be unusable and reject it. This behavior encourages
+authors of TDL documents to exercise strict version controls.
 
-The root level of a hierarchy SHOULD contain a `tui` field. Where it doesn’t
+The root level of a hierarchy SHOULD contain a `tdl` field. Where it doesn’t
 then the recipient can’t assume anything and MUST operate as if no legal basis
 is known. That might mean in practice they reject the entire message. That will
 be a choice for each individual recipient and will likely change as the
@@ -34,20 +34,20 @@ requestor implementations mature.
 
 ### *Evaluation*
 
-The `tui` array entries MUST apply to all descendent nodes.
+The `tdl` array entries MUST apply to all descendent nodes.
 
-Where a descendant node contains an `tui` field the ancestor `tui` entry is
-**replaced**. This is needed to enable a general TUI entry and the subsequent
-signaling of exclusions subject to different TUIs.
+Where a descendant node contains an `tdl` field the ancestor `tdl` entry is
+**replaced**. This is needed to enable a general TDL entry and the subsequent
+signaling of exclusions subject to different TDLs.
 
-For example; a root node containing an `tui` field and one entry would apply to
+For example; a root node containing an `tdl` field and one entry would apply to
 all data in the data structure. See the following example with highlighting
 added.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
-    "tui": [ "https://ex.io/eu-ads-v1.html" ],
+    "tdl": [ "https://ex.io/eu-ads-v1.html" ],
     "device": {
         "make": "Samsung",
         "model": "SCH-I535",
@@ -64,15 +64,15 @@ added.
 }
 ```
 
-For example; a leaf node containing an `tui` field with a different value to its
+For example; a leaf node containing an `tdl` field with a different value to its
 ancestor would signal that the leaf node alone was subject to the subsequent
 legal basis. The following example modifies the previous example by including
-different `tui` labels for the `device` and `user` nodes.
+different `tdl` labels for the `device` and `user` nodes.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
-    "tui": [ "https://ex.io/eu-ads-v1.html" ],
+    "tdl": [ "https://ex.io/eu-ads-v1.html" ],
     "device": {
         "make": "Samsung",
         "model": "SCH-I535",
@@ -82,11 +82,11 @@ different `tui` labels for the `device` and `user` nodes.
         "geo": {
             "country": "USA"
         }
-        "tui": [ "https://ex.io/eu-meta-v3.html" ],
+        "tdl": [ "https://ex.io/eu-meta-v3.html" ],
     },
     "user": {
         "id": "bd5adc55dcbab4bf090604df4f543d90b09f0c88",
-        "tui": [ "https://ex.io/eu-ids-d-v2.html" ],
+        "tdl": [ "https://ex.io/eu-ids-d-v2.html" ],
     }
 }
 ```
@@ -94,20 +94,20 @@ different `tui` labels for the `device` and `user` nodes.
 ### Filtering
 
 Recipients will create masks of the data model’s tree structure containing only
-`tui` array entries that list the entries that they wish to include or reject
+`tdl` array entries that list the entries that they wish to include or reject
 for specific purposes.
 
 For example; if a recipient wished to create a copy of the source data
-containing only TUIs that were acceptable to them for onward sharing they would
-apply a mask containing their allowed TUIs for onwards sharing.
+containing only TDLs that were acceptable to them for onward sharing they would
+apply a mask containing their allowed TDLs for onwards sharing.
 
 Stripping the `user` node would be achieved in the following example by
-rejecting the TUI value `https://ex.io/eu-ids-d-v2.html`.
+rejecting the TDL value `https://ex.io/eu-ids-d-v2.html`.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
-    "tui": [ "https://ex.io/eu-ads-v1.html" ],
+    "tdl": [ "https://ex.io/eu-ads-v1.html" ],
     "device": {
         "make": "Samsung",
         "model": "SCH-I535",
@@ -117,11 +117,11 @@ rejecting the TUI value `https://ex.io/eu-ids-d-v2.html`.
         "geo": {
             "country": "USA"
         }
-        "tui": [ "https://ex.io/eu-meta-v3.html" ],
+        "tdl": [ "https://ex.io/eu-meta-v3.html" ],
     },
     "user": {
         "id": "bd5adc55dcbab4bf090604df4f543d90b09f0c88",
-        "tui": [ "https://ex.io/eu-ids-d-v2.html" ],
+        "tdl": [ "https://ex.io/eu-ids-d-v2.html" ],
     }
 }
 ```

--- a/Proposal.md
+++ b/Proposal.md
@@ -29,9 +29,9 @@ Contributors:
   unique identifier within a scheme agreed by the parties. A URL implementation
   remains the primary example.
 - Modified the CSP changes to require the user agent to confirm that the user
-  has accepted at least on the TDL values. This is needed to prevent web
+  has accepted at least one of the TDL values. This is needed to prevent web
   browsers being used to obtain content protected by copyright via display to
-  users.
+  people.
 
 ## Executive Summary
 

--- a/Proposal.md
+++ b/Proposal.md
@@ -10,50 +10,98 @@ Contributors:
     of the Federation for Internet Alerts)
 -   Alan Chapell (Counsel: Privacy, Competition, AI)
 -   Tim Cowen (Chair, Antitrust Practice at Preiskel & Co LLP)
--   Stephen Kinsella OBE (EU Lawyer, Founder of Clean Up The Internet, Founder of
-    Law For Change, Chair of Trustees at Press Justice Project, Deputy Chair at
-    Reprieve, Senior Advisor Flint Global, Director Stroud Book Festival)
+-   Stephen Kinsella OBE (EU Lawyer, Founder of Clean Up The Internet, Founder
+    of Law For Change, Chair of Trustees at Press Justice Project, Deputy Chair
+    at Reprieve, Senior Advisor Flint Global, Director Stroud Book Festival)
 -   Joshua Koran (Koran Consulting)
 -   Richard Reeves (Managing Director at AOP (Association of Online Publishers))
 
+## Change History
+
+| **Date**           | **Change Summary**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 20th February 2026 | Added a use case concerning licensing content protected by copyright for Artificial Intelligence (AI) purposes. General text modified to reflect this expansion.<br>Replaced TUI (Legal Basis URL) with TUI (Terms Unique Identifier) as this is more general and suited to a wider range of use cases. The TUI is not restricted to being a Universal Resource Location (URL) and could be any unique identifier within a scheme agreed by the parties. A URL implementation remains the primary example.<br>Modified the CSP changes to require the user agent to confirm that the user has accepted at least on the TUI values. This is needed to prevent web browsers being used to obtain content protected by copyright via display to users. |
+
 ## Executive Summary
 
-This proposal provides a signal to all entities and web browser vendors
-concerning the legal basis under which data is collected, stored, used, and
-restricted such that recipients can understand their contractual obligations. It
-can be used with any data storage mechanism including those within organizations
-and across organizations. In this initial iteration HTTP cookies and OpenRTB are
-considered.
+Digital data, whether created by people as they navigate the web in the form of
+cookies or similar technologies, or content that is created by publishers and
+subject to copyright has at least one feature in common. They are both subject
+to laws, either data protection or copyright. The fact that one set of laws
+considers data about people, and the other content that is subject to copyright
+is immaterial from a purely technical standards perspective. This proposal seeks
+to raise awareness of the similarities and present a universal low level
+solution to address abuses of copyright and privacy.
+
+This proposal provides a signal set by those providing data to those receiving
+data to indicate the terms under which the data is collected, stored, used, and
+restricted such that recipients can understand their contractual obligations and
+either reject or accept terms.
+
+Intermediaries that facilitate the data exchanges such as web browser vendors
+can use these signals to facilitate data exchange. The signal can be used with
+any data storage mechanism including those within organizations and across
+organizations. In this initial iteration HTTP cookies, Open Real Time Bidding
+(“OpenRTB”), and Artificial Intelligence (“AI”) are considered as non-exhaustive
+examples.
+
+When considering the proposal it is essential to recognize that a considerable
+volume of copyright protected content is made available without direct payment
+to people in return for exposure to advertising. The commercial relationship
+between copyright protected content and data used in advertising is significant.
+
+Whilst the proposal is comprehensive to cover many use cases the text changes to
+four existing technical standards needed to achieve the goals of the proposal
+are short. See the companion documents [OpenRTB](OpenRTB.md), [HTTP
+Cookies](IETF-HTTP.md), [Content Security Policy 2](CSP.md), and
+[Robots.txt](IETF-Robots.md).
 
 ## Abstract
 
-This cross standards bodies (IAB, IETF, W3C) proposal enables web browser data
-interoperability between internet domains to support competition and innovation
-whilst improving the information available to people, publishers, and web
-browser vendors. With additional information privacy can be improved via
-enforcement without restricting interoperability.
+This cross standards bodies (IAB, IETF, W3C) proposal enables data
+interoperability between parties who agree on clearly identifiable terms. It
+supports competition, privacy, and copyright protection by improving the
+information available to people, regulators, publishers, and web browser
+vendors. With additional information privacy and copyright can be improved via
+enforcement of terms without restricting interoperability.
 
 This proposal consists of a data model that attaches a label in the form of an
-immutable Universal Resource Identifier (URI) field to web browser storage,
-starting with all cookies and the OpenRTB protocol used in advertising. The URL
-links to a document describing the legal basis used for the collection, storage,
-use, any onward use, and restrictions related to the associated data such that
-recipients can share or use the data based on rules defined by the sender and
-facilitate reporting on compliance against those rules to any other entity.
+immutable Terms Unique Identifier (TUI) field to digital content, web browser
+storage, and any onward use of the data. Examples cover content subject to
+copyright, all web cookies, and the OpenRTB protocol used in advertising. The
+general term for the concept is a data label, i.e. “data that has a label
+attached to it which describes the terms under which it is being provided by the
+sender to the recipient such that the recipient can either accept or reject
+those terms unambiguously”.
+
+The TUI is a reference to an immutable document describing the terms and
+conditions under which the data is made available including collection, storage,
+initial use, any onward use, and restrictions related to the associated data
+such that recipients can share or use the data based on rules defined by the
+sender and facilitate reporting on compliance against those rules to any other
+entity.
 
 The approach combines both engineering and contract law to promote a
 decentralized architecture critical to the modern Open Web and support more
 flexibility around the data sharing that is and is not allowed, recognizing not
-all data is personal data, and that people and publishers are the most important
-constituents of the web as the data subject and data controller.
+all data is personal data, use of copyright material must be controlled by
+copyright holders, and that people and publishers are the most important
+constituents of the web as the data subject, data controller, or copyright
+holder.
 
 Where data is not personal data it can be labelled as such so that any entity
 can understand why it is not personal data.
 
+Where a permissive license for use is provided by the copyright holder then all
+parties in recipe of the material protected by copyright can be certain that
+they have legitimate right to use the copyrighted material.
+
 ## Motivation
 
-The modern Open Web requires a viable advertising funded business model. The
-current model suffers from two constraints.
+The modern Open Web requires a viable advertising funded business model and
+protections for copyright holders so that they can decide if and how to license
+their copyrighted material for onward use. The current model suffers from the
+following constraints.
 
 1.  Web browser vendors seek to restrict data interoperability by defining a
     “privacy boundary” based solely on the single dimension of registerable
@@ -62,6 +110,10 @@ current model suffers from two constraints.
 2.  The programmatic advertising supply chains cannot easily demonstrate
     compliance with legal obligations and publishers lack the control needed to
     improve control over their data.
+3.  Those ingesting copyrighted material such as AI vendors cannot be certain
+    that they have done so legally and in compliance with terms defined and
+    agreed with copyright holders. This uncertainty creates liability for onward
+    use.
 
 More recently Privacy Enhancing Technologies (PETs) based on purely technical
 methods of restricting specific types of data processing or data outputs have
@@ -70,7 +122,7 @@ interoperability.
 
 A method of providing the value to publishers and advertisers of open
 interoperability is needed that at the same time adds sufficient information to
-make this interoperability trustworthy.
+make this interoperability trustworthy and legally certain.
 
 ### Web Browsers
 
@@ -119,20 +171,42 @@ bases, perhaps by personalizing advertising when they only have the right to use
 data for measurement, will risk being caught and can then be sanctioned by their
 peers or the relevant authorities.
 
+### Artificial Intelligence
+
+An automated crawler used by an AI vendor to access a website can observe from
+the CSP, robots.txt file, or HTML elements, the terms under which the content is
+being provided and only access, store, and make use of that content when the AI
+vendor has approved use of those terms.
+
+Once content has been marked with a data label in an agreed form that is
+undisputed then the copyright holder will have concrete proof that a breach of
+license has occurred when their terms have not been respected.
+
+Where content has made available under terms that allow for onward use in
+discovery of the original content but restricts use in creating derivative works
+including the training of Large Language Models (LLMs) and the copyright holder
+discovers that these terms were not adhered to then they will have concrete
+evidence to support any claim for infringement.
+
+The benefits of using the same approach to label all data in all situations
+avoids fragmentation aiding implementation.
+
 ### Competition
 
 Competition regulators are now seeking remedies for abuses associated with
-monopolization of digital markets.
-See appendix [1](Appendix1.md) and [2](Appendix2.md).
+monopolization of digital markets. See appendix
+[1](../../../AppData/Roaming/Microsoft/Word/Appendix1.md),
+[2](../../../AppData/Roaming/Microsoft/Word/Appendix2.md), and
+[3](../../../AppData/Roaming/Microsoft/Word/Appendix3.md).
 
 Data protection regulators are seeking remedies to risks associated with
 potentially unlawful use of personal data.
 
 Competition regulators are favoring remedies to address exclusionary conduct,
 such as requiring that data that is captured and used within a monopolist
-organization be made available to other market participants on fair, reasonable,
-and non-discriminatory terms.[^2] Such access remedies are proven to address
-monopolies in other sectors such as telecoms.
+organization being made available to other market participants on fair,
+reasonable, and non-discriminatory terms.[^2] Such access remedies are proven to
+address monopolies in other sectors such as telecoms.
 
 [^2]: <https://www.documentcloud.org/documents/25196894-doj-filing-re-google-antitrust-remedies>
 
@@ -144,6 +218,10 @@ browser vendors to restrict, or threaten to restrict, open interoperability. The
 web browser vendor will “keep score” and cease to decide data policies for
 others. Web browser vendors will neither define the rules of the “game” or be a
 “player” in it.
+
+AI vendors are being investigated for abuse of copyright which varies widely by
+jurisdiction. Those publishers that implement data labels will remove any
+ambiguity concerning the use of their copyright protected material.
 
 ### Privacy
 
@@ -171,30 +249,51 @@ such as telecoms or payments, to digital.
 ## Introduction
 
 This proposal outlines a simple method that can be applied to any data model –
-including monopolists’ data, OpenRTB, and web browser cookies – to append a data
-label URI to indicate the legal basis that the associated data was collected,
-stored, can be used, and any restrictions.
+including monopolists’ data, copyright protected content, OpenRTB, and web
+browser cookies – to append a data label to indicate the terms that the
+associated data was collected, stored, can be used, and any restrictions. Data
+includes content provided by copyright holders and identifiers and other
+information provided by people or their software when accessing digital
+services.
 
 Web browser vendors can facilitate or restrict interoperability and storage
-functionality based on the provided data label URI and associated rules defined
-by people or entities they trust. When data label URIs are not provided the web
-browser vendor’s existing policies can still apply. The proposal is non-breaking
-to existing implementations and is purely additive.
+functionality based on the provided data label and associated rules defined by
+people or entities they trust. When data label are not provided the web browser
+vendor’s existing policies can still apply. The proposal is non-breaking to
+existing implementations and is purely additive.
 
 OpenRTB participants can decide if they use or pass on data based on the data
-label URI provided in the request. People responsible for data protection can
-build allow and disallow lists of data label URIs and justify to other market
-participants and regulators the decision-making process they have applied
-concerning their activities.
+label provided in the request. People responsible for data protection can build
+allow and disallow lists of data labels and justify to other market participants
+and regulators the decision-making process they have applied concerning their
+activities.
+
+Copyright holders can signal the data label that contains the terms under which
+the copyright protected content is made available. Those accessing the content
+can decide if those terms are acceptable to them and their intended use.
+
+As data labels are immutable documents they are machine readable.
 
 Open-source software licensing practitioners gravitated towards a small number
 of standard licenses. No one writes their own open-source license anymore! The
-same evolution is likely with data label URIs. For example; storing and using
-the hash of an email address, data that is not personal data, or data that is an
-unencrypted random identifier will likely result in a small number of standard
-labels for each. Whilst such an outcome is desirable it is not a requirement for
-the proposal to be implemented. Competition among different data labels is a
-positive outcome.
+same evolution is likely with data label.
+
+For example; storing and using the hash of an email address, data that is not
+personal data, or data that is an unencrypted random identifier will likely
+result in a small number of standard labels for each.
+
+For example; content that is made available for use in discovery but not AI is
+likely to be a broadly similar requirement. Rather than every copyright holder
+creating their own label a small number of standard labels for this use case
+with subtle differences tailor to different legal systems will likely evolve.
+
+Whilst such an outcome is desirable it is not a requirement for the proposal to
+be implemented. Competition among different data labels is a positive outcome.
+Centralization of data labels via technical standards vocabularies such as those
+being debated at the IETF are highly undesirable as they restrict choice and
+create ambiguity that can only be fixed via a license document.[^3]
+
+[^3]: <https://datatracker.ietf.org/doc/draft-ietf-aipref-vocab/>
 
 Where a web browser observes many different data labels, independent data
 analysts can be consulted to advise their user on the risks associated with each
@@ -213,31 +312,47 @@ by data protection regulators certification programmes might attract a better
 score than ones used within an individual business without any external
 certification.
 
+Similarly the results of AI prompts could be accompanied with the data labels
+and copyright holders identities used to provide the result. Over time the
+absence of data labels and copyright holders identities would become an
+indicator that the AI vendor might not be respecting copyright. Access software
+could be offer a warning to people indicating that sources and proof of license
+was not provided.
+
 In summary a new wave of innovation will be unleashed that cannot be predicted
 but that will generate competition among solutions. That innovation will not be
 constrained by the policies individual web browser vendors are prepared to add
-to their code bases.
+to their code bases or the power imbalance between AI vendors and the vast
+majority of copyright holders.
 
 ## Background
 
-GDPR does not define or mention first parties.[^3] All data protection laws
+GDPR does not define or mention first parties.[^4] All data protection laws
 operate on a spectrum considering risk of harm based on the type of data that is
 available. Sensitive data associated with health, or a protected characteristic,
 attracts a different risk to a random identifier that is not connected to a
 person. In many situations people can then choose to accept risks based on
 meaningful consent.
 
-[^3]: <https://www.gov.uk/government/publications/cma-ico-joint-statement-on-competition-and-data-protection-law>
+[^4]: <https://www.gov.uk/government/publications/cma-ico-joint-statement-on-competition-and-data-protection-law>
+
+### Copyright
+
+Copyright holders have a right to decide how or if to license their works. The
+ambiguity associated with AI vendor’s use of digital content threatens to
+decimate creative industries. As governments and regulators seek to implement
+laws or guidelines to protect creative industries they will need to ensure there
+is room for supporting neutral technical standards that support remedies.
 
 ### Web Browsers
 
 Web browsers are limited when defining data protection boundaries by the
-information that they have available to them. As of May 2025, this information
-is incomplete when compared against data protection laws. Web browser vendors
-therefore took the position that the user can identify the organizations
-associated with the web page being visited via the domain name shown in the
-address bar. They believe the user will assume that the domain name signifies
-the organization they are interacting with.
+information that they have available to them. As of February 2026, this
+information is incomplete when compared against data protection laws. Web
+browser vendors therefore took the position that the user can identify the
+organizations associated with the web page being visited via the domain name
+shown in the address bar. They believe the user will assume that the domain name
+signifies the organization they are interacting with.
 
 For example, they assume the letters BBC in the domain name indicate the legal
 entity British Broadcasting Corporation Limited rather than hold any other
@@ -282,7 +397,8 @@ the offering of a service that competes with the larger rival.
 Upgrading the data protection boundary for web browsers will assist web browser
 vendors that are subject to competition regulatory scrutiny as they can
 demonstrate they are no longer preferencing themselves via the current approach.
-Data labels for cookies, or other data, would be applied equally to all.
+Data labels for cookies, copyright protected content, or other data, would be
+applied equally to all.
 
 ### Access Remedies
 
@@ -296,11 +412,11 @@ addressed by attaching a data label that would restrict use of that data.
 ### OpenRTB
 
 Programmatic advertising auctions were developed after web browsers became
-popular. Open Real Time Bidding (“OpenRTB”) is the protocol adopted by market
-participants to efficiently facilitate the necessary information exchanges. The
-resulting AdTech sector is important to the operation of digital markets. Any
-factor that can influence the fairness of the OpenRTB auction is of interest to
-both the market and regulators.
+popular. OpenRTB is the protocol adopted by market participants to efficiently
+facilitate the necessary information exchanges. The resulting AdTech sector is
+important to the operation of digital markets. Any factor that can influence the
+fairness of the OpenRTB auction is of interest to both the market and
+regulators.
 
 OpenRTB defines a request from a publisher, or agent acting on their behalf, to
 an auction exchange that then passes the information about the opportunity to
@@ -343,9 +459,9 @@ themselves in for people are free to decide which experience they prefer.
 Multiple surveys show that privacy is only one of many factors in
 consumer-facing decisions among products and services they choose. Indeed, the
 majority of people in these surveys most often rate other factors higher than
-privacy.[^4]
+privacy.[^5]
 
-[^4]: <https://www.ofcom.org.uk/media-use-and-attitudes/online-habits/online-nation>
+[^5]: <https://www.ofcom.org.uk/media-use-and-attitudes/online-habits/online-nation>
 
 ## Concepts
 
@@ -355,7 +471,7 @@ This proposal;
     existing internet domain name data protection boundaries, TCF, GPP, PET
     output and input data, and others.
 2.  Is decentralized and empowers each data collection and sharing organization
-    to decide on and signal their own policies.
+    to decide on and signal their own terms.
 3.  Recognizes not all the data included in a single OpenRTB transaction is
     subject to the same legal agreement. For example, the non-personal data of
     make and model of the device used by an individual organization might be
@@ -376,35 +492,35 @@ each data using organization’s freedom to choose how to comply with data laws.
 
 ### General Use
 
-Adds a new optional array field named Legal Basis URI shortened to `lbu` to
-all data to provide URIs explaining the legal basis used to collect, share, use,
-and restrict data. Legal basis might also be considered the legal contract that
-MUST be in place between the sender and recipient before the data is
-transferred.
+Adds a new optional array field named Terms Unique Identifier shortened to `tui`
+to all data to provide a reference to a unique document explaining the terms for
+collection, sharing, use, and restrictions associated with the associated data.
+Terms might also include the legal contract that MUST be in place between the
+sender and recipient before the data is transferred.
 
-The `lbu` field MUST be shared along with the data. Put another way, it would
-be a breach of the proposal to pass on data that has an `lbu` label without
-also making the `lbu` label available to the recipient.
+The `tui` field MUST always be shared along with the data. Put another way, it
+would be a breach of the proposal to pass on data that has an `tui` label
+without also making the `tui` label available to the recipient.
 
-Data Users that receive `lbu` labelled data then create inclusion and
-exclusion lists of `lbu` values.
+Data Users that receive `tui` labelled data then create inclusion and exclusion
+lists of `tui` values.
 
-Over time common combinations of legal basis documents will be created and
-amalgamated such that most common data collection, sharing, use, and
-restrictions are covered by common agreements. This is identical to open-source
-software licensing where only a small number of license agreements are now used
-but once there were many more. For example, there could be common “Not personal
-data in the EU”, “EU advertising funded publisher”, or a “California payment
-funded publisher” label documents which cover all common use cases.
+Over time common combinations of terms documents will be created and amalgamated
+such that most common data collection, sharing, use, and restrictions are
+covered by common agreements. This is identical to open-source software
+licensing where only a small number of license agreements are now used but once
+there were many more. For example, there could be common “Not personal data in
+the EU”, “EU advertising funded publisher”, or a “California payment funded
+publisher” label documents which cover all common use cases.
 
-An example data structure with the `lbu` field in an OpenRTB request with
+An example data structure with the `tui` field in an OpenRTB request with
 emphasis added just to the device element is shown.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
     "device": {
-        "lbu": [ "https://ex.io/eu-ads-v1.html" ],
+        "tui": [ "https://ex.io/eu-ads-v1.html" ],
         "make": "Samsung",
         "model": "SCH-I535",
         "os": "Android",
@@ -420,27 +536,66 @@ emphasis added just to the device element is shown.
 }
 ```
 
-A similar `lbu` field added to the Set-Cookie response header in HTTP, where
-the data has been replaced with ellipsis for brevity, is shown.
+A similar `tui` field added to the Set-Cookie response header in HTTP, where the
+data has been replaced with ellipsis for brevity, is shown.
 
 ```text
-Set-Cookie: device={ ... } ; Expires=Thu, 21 Oct 2025 07:28:00 GMT; Secure;
-HttpOnly; LBU=https://ex.io/eu-ads-v1.html
+Set-Cookie: device={ ... }; Expires=Thu, 21 Oct 2025 07:28:00 GMT; Secure; 
+HttpOnly;
+TUI=https://ex.io/eu-ads-v1.html;
 ```
 
-For those HTTP clients that do not know how to handle the `lbu` field they
-will just ignore it. Therefore, this is a non-breaking change.
+For those HTTP clients that do not know how to handle the `tui` field they will
+just ignore it. Therefore, this is a non-breaking change.
 
-In the previous examples the `lbu` field label resolves to a document that
-would explain the legal basis under which the `device` field, and all other
-fields that are descendants of it, were collected and can be used including any
-restrictions.
+For those using robots.txt to signal crawlers use of content the `tui` label
+would be added as a new line. See the following example.
 
-Recipients of labelled data will then have additional information to use when
-making decisions concerning storage or interoperability. Allow and disallow
-lists could be created and shared by different organizations and then deployed
-by recipients. Consider the following scenarios.
+```text
+User-Agent: *
+TUI: https://www.facebook.com/legal/automated_data_collection_terms
+Allow: /
+```
 
+The placement of one or more `tui` fields between the `User-Agent` and the
+`Allow` fields indicates the terms under which the allow operation is granted.
+Observe that the URL used for the TUI label is one that Meta include in their
+current robots.txt in the form of a comment that is not easily identifiable to a
+machine.[^6]
+
+[^6]: <https://facebook.com/robots.txt>
+
+When used in HTML any content element can have the `tui` attribute added to it.
+See the following example of a division containing many paragraphs.
+
+```HTML
+<div tui=”https://ex.io/eu-ads-v1.html”>
+<p>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+</p>
+<p>
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+</p>
+</div>
+```
+
+Any HTML element could have the `tui` attribute added including the `html` or
+the `body` element.
+
+In the previous examples the `tui` field label resolves to a document that
+provides the terms under which the associated data, and all other data that
+descends from it, are to be used including any restrictions.
+
+Recipients of labelled data will then have additional information when making
+decisions concerning storage, use, or interoperability. Allow and disallow lists
+for `tui` documents could be created and shared by different organizations and
+then deployed by recipients. Consider the following scenarios.
+
+-   An AI vendor’s crawler would only retrieve content that was associated with
+    a pre-authorized `tui` document. If allowed the `tui` document would then be
+    attached to all onwards uses of that content and verified before using the
+    content. For example; the same content with a `tui` document that allows for
+    use with discovery might be prohibited for use with AI.
 -   A web browser might allow all third-party cookies to be shared where the
     cookie is labelled and Content Security Policies (CSPs) allow provided
     labels. Rather than restricting third-party cookies they could provide a
@@ -448,7 +603,7 @@ by recipients. Consider the following scenarios.
     period of time and provide the user the option to disallow specific legal
     basis.
 -   As users become educated about the possibilities a web browser’s user could
-    configure their `lbu` values allow and disallow lists to be synchronized
+    configure their `tui` values allow and disallow lists to be synchronized
     from other sources including their trusted data protection authority or a
     well-known entity that curates allow and disallow lists. Web browser vendors
     would not need to do this on behalf of their users and thus avoid an
@@ -462,7 +617,7 @@ by recipients. Consider the following scenarios.
 -   A trade body or law firm might maintain a list of allowed and disallowed
     values for their members or customers aiding DPO curation of these lists.
 -   Insurance companies might publish lists that attract lower premiums for data
-    protection insurance when used.
+    protection insurance when applied.
 
 ### Web Browser
 
@@ -489,26 +644,33 @@ news.files.bbci.co.uk platform.twitter.com…
 ```
 
 We can see from this CSP that only JavaScript from known sources is allowed to
-be included as indicated by `script-src`. `script-src` is an example of a
-key that can be included in CSPs. There are many others for resource types
-including fonts, styles, images, and more.
+be included as indicated by `script-src`. `script-src` is an example of a key
+that can be included in CSPs. There are many others for resource types including
+fonts, styles, images, and more.
 
 Keys are separated by semi-colons`;`.
 
-The proposal requires adding an additional key named `lbu-src` to the CSP
-which is a simplified implementation of the keys used for JavaScript or any
-other content type. The values following `lbu-src` are the values accepted and
+The proposal requires adding an additional key named `tui-src` to the CSP which
+is a simplified implementation of the keys used for JavaScript or any other
+content type. The values following `tui-src` are the values accepted and
 complied with by the domain owner.
 
 A simple example with two values follows.
 
 ```text
-content-security-policy: lbu https://ex.io/eu-ads-v1.html
-https://ex.io/eu-meta-v3.html**;** script-src 'strict-dynamic'
+content-security-policy: tui-src https://ex.io/eu-ads-v1.html
+https://ex.io/eu-meta-v3.html; script-src 'strict-dynamic'
 'nonce-QnDzo0LUa5zAu6ZpdTcHHwOuuRMjt1xGRukWMmc72UhAKUbZAx' 'self'
 'report-sample' 'unsafe-inline' assets.wearehearken.eu cdn.syndication.twimg.com
 connect.facebook.net c.files.bbci.co.uk…
 ```
+
+#### Access
+
+The web browser will only retrieve and display the content where one or more of
+the `tui-src` values has been agreed to by the user of the web browser. There
+will need to be a period of transition where web browsers do not strictly
+enforce this requirement.
 
 #### Writing
 
@@ -517,67 +679,66 @@ shown in the address bar of the web browser no additional checks of the CSP are
 required.
 
 Where the domain associated with the storage operation is different the CSP of
-the domain shown in the address bar MUST include the `lbu` label associated
-with the write operation if the write operation is be successful. The `lbu`
-label is not included the address bar domain’s CSP then the write operation
-fails.
+the domain shown in the address bar MUST include the `tui` label associated with
+the write operation if the write operation is be successful. The `tui` label is
+not included the address bar domain’s CSP then the write operation fails.
 
-This feature ensures that the address bar domain operator controls allowed
-`lbu` label for not just themselves but their suppliers.
+This feature ensures that the address bar domain operator controls allowed `tui`
+label for not just themselves but their suppliers.
 
 #### Retrieval
 
 When a request is received by a web browser and there is an opportunity to
 provide cookies or other data in response a check MUST be performed against the
-CSP associated with the request and only those labels that relate to `lbu`
-labels that are contained in the `lbu` list of the CSP can be provided in
+CSP associated with the request and only those labels that relate to `tui`
+labels that are contained in the `tui` list of the CSP can be provided in
 response.
 
 Consider a cookie that is written using the following syntax in an HTTP header.
 
 ```text
 Set-Cookie: device={ ... } ; Expires=Thu, 21 Oct 2025 07:28:00 GMT; Secure;
-HttpOnly; LBU=https://ex.io/eu-ads-v1.html
+HttpOnly;
+TUI=https://ex.io/eu-ads-v1.html
 ```
 
 The value of that cookie MUST only be provided where the requestor’s CSP
-indicates that they accept the `lbu` label `https://ex.io/eu-ads-v1.html`.
-The following is an example of such a CSP.
+indicates that they accept the `tui` label `https://ex.io/eu-ads-v1.html`. The
+following is an example of such a CSP.
 
 ```text
-content-security-policy: lbu-src https://ex.io/eu-ads-v1.html;
+content-security-policy: tui-src https://ex.io/eu-ads-v1.html;
 ```
 
-If the CSP does not contain a matching `lbu` label, then no information will
-be provided. As such the requestor will need to know the `lbu` label used when
+If the CSP does not contain a matching `tui` label, then no information will be
+provided. As such the requestor will need to know the `tui` label used when
 writing the key before it can retrieve the value.
 
 The concepts apply to all methods of retrieving data including cookies and API
-calls. As such existing interfaces do not need to be modified as the `lbu`
+calls. As such existing interfaces do not need to be modified as the `tui`
 labels are communicated via established complementary channels. Only the methods
 associated with writing data within web browsers need to be modified.
 
 Optionally the web browser can record the identity of the requesting entity, the
-`lbu` labels, and whether the data was returned or not. Using these labels web
+`tui` labels, and whether the data was returned or not. Using these labels web
 browser vendors can provide reports to people, or in aggregate across consenting
 people, concerning the legal basis under which data is stored and provided and
 to whom.
 
 ### Examples
 
-Consider three `lbu` labels L1, L2, and L3 and three actor domains A, B, and
-C.
+Consider three `tui` labels L1, L2, and L3 and three actor domains A, B, and C.
 
--   A writes the value Y to key X with `lbu` L1.
--   B then seeks to read key X from A with `lbu` L1. Y is returned.
--   C then seeks to read key X from A with `lbu` L2. The operation is
-    disallowed and Y is not returned.
--   A then seeks to read key X from A with `lbu` L3 having dropped the use of
+-   A writes the value Y to key X with `tui` L1.
+-   B then seeks to read key X from A with `tui` L1. Y is returned.
+-   C then seeks to read key X from A with `tui` L2. The operation is disallowed
+    and Y is not returned.
+-   A then seeks to read key X from A with `tui` L3 having dropped the use of
     L1. The operation is disallowed and Y is not returned. This is because the
-    `lbu` value does not match L1 provided when A wrote key X.
+    `tui` value does not match L1 provided when A wrote key X.
 
 Any changes to restrict third-party cookies and other data exchanges MUST not be
-applied when `lbu` values are provided.
+applied when `tui` values are provided.
 
 Now consider A and B using C to provide supplier resources.
 
@@ -585,29 +746,31 @@ Now consider A and B using C to provide supplier resources.
 -   B’s CSP includes L1 and L3 but not L2.
 -   C’s CSP includes L1, L2, and L3.
 -   C operating as a supplier resource for A writes the value Y to key X with
-    `lbu` L1. The operation succeeds.
+    `tui` L1. The operation succeeds.
 -   C operating as a supplier resource for B reads the key X. The operation
     succeeds.
 -   C operating as a supplier resource for A writes the value Y to key W with
-    `lbu` L2. The operation succeeds.
+    `tui` L2. The operation succeeds.
 -   C operating as a supplier resource for B reads the key W. The operation
-    fails because B does not permit operations with L2 which is the `lbu`
-    value used to write key W.
+    fails because B does not permit operations with L2 which is the `tui` value
+    used to write key W.
 
 ## Benefits
 
 The proposal is intended to bring clarity to data processing such that this
 clarity can be communicated to people to aid them in establishing trust with
-digital services no matter their relation to visible internet domain names.
+digital services no matter their relation to visible internet domain names or
+the method used to retrieve information such as an AI prompt response.
 
 Organizations require a neutral, universal method of signaling to other entities
-the restrictions and permitted uses of data. Not all the data collected and then
-subsequently shared or used will be subject to the same restrictions. For
-example; the make and model of device, IP address, and an identifier used for
-advertising measurement might all be subject to different laws and business
-bases. Such signaling needs to describe the legal basis under which each type of
-data was collected or generated, shared, and can be used in terms and language
-written for data controllers and processors.
+the restrictions and permitted uses of data including copyright protected
+material. Not all the data collected and then subsequently shared or used will
+be subject to the same restrictions. For example; the make and model of device,
+IP address, and an identifier used for advertising measurement might all be
+subject to different laws and business bases. Such signaling needs to describe
+the legal basis under which each type of data was collected or generated,
+shared, and can be used in terms and language written for data controllers and
+processors.
 
 For example; someone might be asked if they are happy for content to be
 personalized for them based on their browsing history. The definition of content
@@ -626,35 +789,49 @@ from shared legal basis. Where other publishers are not comfortable accepting
 these legal basis then the publisher will know they will not be contributing to
 other publishers via their chosen suppliers.
 
-As legal basis documents become commonly agreed data protection notices will be
-able to incorporate these standard documents reducing divergence and improving
-understanding for all participants.
+For example; a copyright holder might be comfortable making their data available
+only to human’s and not machines. By applying the `tui` label to both
+`robots.txt` and either the CSP or `html` elements they can signal this
+restriction preventing web browsers being used by AI vendors as a way of
+obtaining their copyright protected content.
+
+As terms documents become commonly agreed data protection notices will be able
+to incorporate these standard documents reducing divergence and improving
+understanding for all participants. Information concerning the sources and
+rights to use data in derivative works such as AI generated content becomes
+clear and measurable.
 
 Interoperability can be restored across the web, publishers gain control over
-the proven benefits of interoperability, user privacy in practice improved, and
-competition remedies in the form of data access become practical.
+the proven benefits of interoperability, copyright protection, user privacy in
+practice improved, and competition remedies in the form of data access become
+practical.
 
 ## Out of Scope
 
-Reference to specific privacy laws other than as examples. This proposal is only
-concerned with the technical method of signaling bases used to collect, share,
-use, and restrict data whether personal or non-personal.
+Reference to specific privacy and copyright laws other than as examples. This
+proposal is only concerned with the technical method of signaling terms used to
+collect, share, use, and restrict data whether content, personal, or
+non-personal.
 
-Methods of establishing notices to people or the acceptance of legal basis via
-the construction of lists. These implementations, and the sharing of lists, will
-be a matter of competition among implementors.
+Methods of establishing notices to people or the acceptance of terms via the
+construction of lists. These implementations, and the sharing of lists, will be
+a matter of competition among implementors.
 
 The problems of people consenting and providing proof that consent was given.
 The proposal might evolve to do so in a future iteration via the addition of
-cryptographic proofs similar to the digital signatures available in email.
+cryptographic proofs similar to the digital signatures available in email or
+tokens that include the `tui` document, a unique identifier for the content, the
+identifies of the sending and receiving parties, and the date and time of the
+trans
 
-Explicitly identifying bad actors who are not respecting the legal basis
-documents. Such a feature could be added in future iterations once the direction
-is established and proven. However, knowledge of many interactions will increase
+Explicitly identifying bad actors who are not respecting the terms documents.
+Such a feature could be added in future iterations once the direction is
+established and proven. However, knowledge of many interactions will increase
 the risk of bad actors being identified with evidence. For example; claiming
 data is not personal data when it is in fact demonstrably being used as personal
 data in breach of relevant laws. For example; sharing data with entities that
-are restricted under a commercial basis.
+are restricted under a commercial basis. For example; using content protected by
+copyright in a manner that breaches the terms.
 
 Methods of aggregating data and data labels to observe compliance. This is a
 matter of competition once a method of labelling data is established.
@@ -662,16 +839,21 @@ matter of competition once a method of labelling data is established.
 Using data labels to label content such that digital rights holders can express
 the basis under which the content is provided.
 
-## LBU guidance
+## TUI guidance
 
-Users of this proposal SHOULD consider the following.
+Users of this proposal MUST consider the following.
 
--   LBU labels should be short, unchanging once published, and publicly
-    available to reduce additional data overhead.
+-   TUI values must be unchanging once published.
+
+Users of this proposal SHOULD consider the following if their documents are to
+be widely used.
+
+-   TUI values should be short, and publicly available to reduce additional data
+    overhead.
 -   To avoid administrative complexity in practice organizations will benefit
-    from working together to agree on common legal basis documents for common
+    from working together to agree on common terms documents for common
     purposes.
--   Applying legal basis documents to groups of related data is preferable for
+-   Applying terms documents to groups of related data is preferable for
     efficiency than creating legal basis documents for each individual data
     item. For example, groups of data like those describing the location or
     characteristics of a device are preferable to ones that describe each
@@ -679,28 +861,29 @@ Users of this proposal SHOULD consider the following.
 
 Users of this proposal MAY wish to consider the following.
 
--   When interacting with people to incorporate LBUs into their user
+-   When interacting with people to incorporate TUIs into their user
     documentation in addition to information that describes the data stored on
     the device. For example; updating privacy policies to not only list cookies,
     but also data use beyond the web browser.
--   When not interacting with people, to publish the LBUs that they share or use
+-   When not interacting with people, to publish the TUIs that they share or use
     data under such that they are easily inspectable by other market
     participants.
--   Seek certification of legal basis documents from relevant authorities such
-    as the Information Commissioner’s Office (ICO) that operate such
-    certification schemes. Such certification schemes are not within the scope
-    of this proposal. It is likely such certification activities would be
-    carried out by Data Protection Officers and not the engineers that implement
-    support for the LBU signal.
+-   Seek certification of terms documents from relevant authorities such as the
+    Information Commissioner’s Office (ICO) that operate such certification
+    schemes. Such certification schemes are not within the scope of this
+    proposal. It is likely such certification activities would be carried out by
+    Data Protection Officers and not the engineers that implement support for
+    the TUI signal.
 
 ## Conclusion
 
 A method is urgently needed to enable all participants including people,
-regulators, civil society, publishers, advertisers, and suppliers, to trust
-digital services. The debate over cookies and data sharing is maturing.
-Identifiers and data sharing play a pivotal role in adjacent markets like
-payments and telecoms. Digital markets need to mature and adopt similar
-principles. This proposal is simple, low level, and will unleash innovation.
+regulators, civil society, publishers, content rights holders, advertisers, and
+suppliers, to trust digital services. The debate over cookies, data sharing, and
+use of copyright material to create derivative works, is maturing. Identifiers
+and data sharing play a pivotal role in adjacent markets like payments and
+telecoms. Digital markets need to mature and adopt similar principles. This
+proposal is simple, low level, and will unleash innovation if widely adopted.
 
 Organizations commonly publish privacy policies that are readily available for
 people to understand how data is used. Some organizations require people to
@@ -726,9 +909,10 @@ they can use organizational measures to restrict and monitor for abuse.
 The following technical standards need to be modified and implemented for this
 proposal to be realized.
 
-1. [OpenRTB](OpenRTB.md)
-2. [HTTP Cookies](IETF-HTTP.md)
-3. [Content Security Policy 2](CSP.md)
+1.  [OpenRTB](../../../AppData/Roaming/Microsoft/Word/OpenRTB.md)
+2.  [HTTP Cookies](../../../AppData/Roaming/Microsoft/Word/IETF-HTTP.md)
+3.  [Content Security Policy 2](../../../AppData/Roaming/Microsoft/Word/CSP.md)
+4.  [Robots.txt](../../../AppData/Roaming/Microsoft/Word/IETF-Robots.md)
 
 Each of the links in the above list provides the proposed text changes to these
 documents.

--- a/Proposal.md
+++ b/Proposal.md
@@ -2,25 +2,36 @@
 
 Editor:
 
--   James Rosewell (51Degrees and Movement for an Open Web)
+- James Rosewell (51Degrees and Movement for an Open Web)
 
 Contributors:
 
--   Jason Bier (General Counsel and Chief Privacy Officer at Adstra; President
-    of the Federation for Internet Alerts)
--   Alan Chapell (Counsel: Privacy, Competition, AI)
--   Tim Cowen (Chair, Antitrust Practice at Preiskel & Co LLP)
--   Stephen Kinsella OBE (EU Lawyer, Founder of Clean Up The Internet, Founder
-    of Law For Change, Chair of Trustees at Press Justice Project, Deputy Chair
-    at Reprieve, Senior Advisor Flint Global, Director Stroud Book Festival)
--   Joshua Koran (Koran Consulting)
--   Richard Reeves (Managing Director at AOP (Association of Online Publishers))
+- Jason Bier (General Counsel and Chief Privacy Officer at Adstra; President of
+  the Federation for Internet Alerts)
+- Alan Chapell (Counsel: Privacy, Competition, AI)
+- Tim Cowen (Chair, Antitrust Practice at Preiskel & Co LLP)
+- Stephen Kinsella OBE (EU Lawyer, Founder of Clean Up The Internet, Founder of
+  Law For Change, Chair of Trustees at Press Justice Project, Deputy Chair at
+  Reprieve, Senior Advisor Flint Global, Director Stroud Book Festival)
+- Joshua Koran (Koran Consulting)
+- Richard Reeves (Managing Director at AOP (Association of Online Publishers))
 
 ## Change History
 
-| **Date**           | **Change Summary**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 20th February 2026 | Added a use case concerning licensing content protected by copyright for Artificial Intelligence (AI) purposes. General text modified to reflect this expansion.<br>Replaced TUI (Legal Basis URL) with TUI (Terms Unique Identifier) as this is more general and suited to a wider range of use cases. The TUI is not restricted to being a Universal Resource Location (URL) and could be any unique identifier within a scheme agreed by the parties. A URL implementation remains the primary example.<br>Modified the CSP changes to require the user agent to confirm that the user has accepted at least on the TUI values. This is needed to prevent web browsers being used to obtain content protected by copyright via display to users. |
+### February 2026
+
+- Added a use case concerning licensing content protected by copyright for
+  Artificial Intelligence (AI) purposes. General text modified to reflect this
+  expansion.
+- Replaced LBU (Legal Basis URL) with TDL (Terms Document Locator) as this is
+  more general and suited to a wider range of use cases. The TDL is not
+  restricted to being a Universal Resource Location (URL) and could be any
+  unique identifier within a scheme agreed by the parties. A URL implementation
+  remains the primary example.
+- Modified the CSP changes to require the user agent to confirm that the user
+  has accepted at least on the TDL values. This is needed to prevent web
+  browsers being used to obtain content protected by copyright via display to
+  users.
 
 ## Executive Summary
 
@@ -66,7 +77,7 @@ vendors. With additional information privacy and copyright can be improved via
 enforcement of terms without restricting interoperability.
 
 This proposal consists of a data model that attaches a label in the form of an
-immutable Terms Unique Identifier (TUI) field to digital content, web browser
+immutable Terms Document Locator (TDL) field to digital content, web browser
 storage, and any onward use of the data. Examples cover content subject to
 copyright, all web cookies, and the OpenRTB protocol used in advertising. The
 general term for the concept is a data label, i.e. “data that has a label
@@ -74,7 +85,7 @@ attached to it which describes the terms under which it is being provided by the
 sender to the recipient such that the recipient can either accept or reject
 those terms unambiguously”.
 
-The TUI is a reference to an immutable document describing the terms and
+The TDL is a reference to an immutable document describing the terms and
 conditions under which the data is made available including collection, storage,
 initial use, any onward use, and restrictions related to the associated data
 such that recipients can share or use the data based on rules defined by the
@@ -103,17 +114,17 @@ protections for copyright holders so that they can decide if and how to license
 their copyrighted material for onward use. The current model suffers from the
 following constraints.
 
-1.  Web browser vendors seek to restrict data interoperability by defining a
-    “privacy boundary” based solely on the single dimension of registerable
-    domain names. This restriction is popularly understood as the deprecation of
-    third-party cookies.
-2.  The programmatic advertising supply chains cannot easily demonstrate
-    compliance with legal obligations and publishers lack the control needed to
-    improve control over their data.
-3.  Those ingesting copyrighted material such as AI vendors cannot be certain
-    that they have done so legally and in compliance with terms defined and
-    agreed with copyright holders. This uncertainty creates liability for onward
-    use.
+1. Web browser vendors seek to restrict data interoperability by defining a
+   “privacy boundary” based solely on the single dimension of registerable
+   domain names. This restriction is popularly understood as the deprecation of
+   third-party cookies.
+2. The programmatic advertising supply chains cannot easily demonstrate
+   compliance with legal obligations and publishers lack the control needed to
+   improve control over their data.
+3. Those ingesting copyrighted material such as AI vendors cannot be certain
+   that they have done so legally and in compliance with terms defined and
+   agreed with copyright holders. This uncertainty creates liability for onward
+   use.
 
 More recently Privacy Enhancing Technologies (PETs) based on purely technical
 methods of restricting specific types of data processing or data outputs have
@@ -316,8 +327,8 @@ Similarly the results of AI prompts could be accompanied with the data labels
 and copyright holders identities used to provide the result. Over time the
 absence of data labels and copyright holders identities would become an
 indicator that the AI vendor might not be respecting copyright. Access software
-could be offer a warning to people indicating that sources and proof of license
-was not provided.
+could offer a warning to people indicating that sources and proof of license was
+not provided.
 
 In summary a new wave of innovation will be unleashed that cannot be predicted
 but that will generate competition among solutions. That innovation will not be
@@ -467,43 +478,43 @@ privacy.[^5]
 
 This proposal;
 
-1.  Is intended to operate in parallel with other signaling methods including
-    existing internet domain name data protection boundaries, TCF, GPP, PET
-    output and input data, and others.
-2.  Is decentralized and empowers each data collection and sharing organization
-    to decide on and signal their own terms.
-3.  Recognizes not all the data included in a single OpenRTB transaction is
-    subject to the same legal agreement. For example, the non-personal data of
-    make and model of the device used by an individual organization might be
-    shared under a different legal basis to the personal data of an individual
-    when both are included in the same data structure. Another example; could be
-    the legal basis for each individual enhanced identifier included in the
-    request might be different.
-4.  Signal non-personal data - Most data protection laws require an impact
-    assessment to determine the risk associated with the data or processing.
-    Where non-personal data is concerned no basis is required for collection and
-    processing. An improvement this proposal enables is an explanation
-    concerning why non-personal data is not personal data thus clearly signaling
-    to others why the data is not personal data and is not subject to any
-    restrictions. This proposal supports the provision of such an explanation.
+1. Is intended to operate in parallel with other signaling methods including
+   existing internet domain name data protection boundaries, TCF, GPP, PET
+   output and input data, and others.
+2. Is decentralized and empowers each data collection and sharing organization
+   to decide on and signal their own terms.
+3. Recognizes not all the data included in a single OpenRTB transaction is
+   subject to the same legal agreement. For example, the non-personal data of
+   make and model of the device used by an individual organization might be
+   shared under a different legal basis to the personal data of an individual
+   when both are included in the same data structure. Another example; could be
+   the legal basis for each individual enhanced identifier included in the
+   request might be different.
+4. Signal non-personal data - Most data protection laws require an impact
+   assessment to determine the risk associated with the data or processing.
+   Where non-personal data is concerned no basis is required for collection and
+   processing. An improvement this proposal enables is an explanation concerning
+   why non-personal data is not personal data thus clearly signaling to others
+   why the data is not personal data and is not subject to any restrictions.
+   This proposal supports the provision of such an explanation.
 
 The proposal enables innovation concerning the use of data without compromising
 each data using organization’s freedom to choose how to comply with data laws.
 
 ### General Use
 
-Adds a new optional array field named Terms Unique Identifier shortened to `tui`
+Adds a new optional array field named Terms Document Locator shortened to `tdl`
 to all data to provide a reference to a unique document explaining the terms for
 collection, sharing, use, and restrictions associated with the associated data.
 Terms might also include the legal contract that MUST be in place between the
 sender and recipient before the data is transferred.
 
-The `tui` field MUST always be shared along with the data. Put another way, it
-would be a breach of the proposal to pass on data that has an `tui` label
-without also making the `tui` label available to the recipient.
+The `tdl` field MUST always be shared along with the data. Put another way, it
+would be a breach of the proposal to pass on data that has an `tdl` label
+without also making the `tdl` label available to the recipient.
 
-Data Users that receive `tui` labelled data then create inclusion and exclusion
-lists of `tui` values.
+Data Users that receive `tdl` labelled data then create inclusion and exclusion
+lists of `tdl` values.
 
 Over time common combinations of terms documents will be created and amalgamated
 such that most common data collection, sharing, use, and restrictions are
@@ -513,14 +524,14 @@ there were many more. For example, there could be common “Not personal data in
 the EU”, “EU advertising funded publisher”, or a “California payment funded
 publisher” label documents which cover all common use cases.
 
-An example data structure with the `tui` field in an OpenRTB request with
+An example data structure with the `tdl` field in an OpenRTB request with
 emphasis added just to the device element is shown.
 
 ```json
 {
     "id": "7979d0c78074638bbdf739ffdf285c7e1c74a691",
     "device": {
-        "tui": [ "https://ex.io/eu-ads-v1.html" ],
+        "tdl": [ "https://ex.io/eu-ads-v1.html" ],
         "make": "Samsung",
         "model": "SCH-I535",
         "os": "Android",
@@ -536,40 +547,40 @@ emphasis added just to the device element is shown.
 }
 ```
 
-A similar `tui` field added to the Set-Cookie response header in HTTP, where the
+A similar `tdl` field added to the Set-Cookie response header in HTTP, where the
 data has been replaced with ellipsis for brevity, is shown.
 
 ```text
 Set-Cookie: device={ ... }; Expires=Thu, 21 Oct 2025 07:28:00 GMT; Secure; 
 HttpOnly;
-TUI=https://ex.io/eu-ads-v1.html;
+TDL=https://ex.io/eu-ads-v1.html;
 ```
 
-For those HTTP clients that do not know how to handle the `tui` field they will
+For those HTTP clients that do not know how to handle the `tdl` field they will
 just ignore it. Therefore, this is a non-breaking change.
 
-For those using robots.txt to signal crawlers use of content the `tui` label
+For those using robots.txt to signal crawlers use of content the `tdl` label
 would be added as a new line. See the following example.
 
 ```text
 User-Agent: *
-TUI: https://www.facebook.com/legal/automated_data_collection_terms
+TDL: https://www.facebook.com/legal/automated_data_collection_terms
 Allow: /
 ```
 
-The placement of one or more `tui` fields between the `User-Agent` and the
+The placement of one or more `tdl` fields between the `User-Agent` and the
 `Allow` fields indicates the terms under which the allow operation is granted.
-Observe that the URL used for the TUI label is one that Meta include in their
+Observe that the URL used for the TDL label is one that Meta include in their
 current robots.txt in the form of a comment that is not easily identifiable to a
 machine.[^6]
 
 [^6]: <https://facebook.com/robots.txt>
 
-When used in HTML any content element can have the `tui` attribute added to it.
+When used in HTML any content element can have the `tdl` attribute added to it.
 See the following example of a division containing many paragraphs.
 
 ```HTML
-<div tui=”https://ex.io/eu-ads-v1.html”>
+<div tdl=”https://ex.io/eu-ads-v1.html”>
 <p>
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 </p>
@@ -579,45 +590,44 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
 </div>
 ```
 
-Any HTML element could have the `tui` attribute added including the `html` or
+Any HTML element could have the `tdl` attribute added including the `html` or
 the `body` element.
 
-In the previous examples the `tui` field label resolves to a document that
+In the previous examples the `tdl` field label resolves to a document that
 provides the terms under which the associated data, and all other data that
 descends from it, are to be used including any restrictions.
 
 Recipients of labelled data will then have additional information when making
 decisions concerning storage, use, or interoperability. Allow and disallow lists
-for `tui` documents could be created and shared by different organizations and
+for `tdl` documents could be created and shared by different organizations and
 then deployed by recipients. Consider the following scenarios.
 
--   An AI vendor’s crawler would only retrieve content that was associated with
-    a pre-authorized `tui` document. If allowed the `tui` document would then be
-    attached to all onwards uses of that content and verified before using the
-    content. For example; the same content with a `tui` document that allows for
-    use with discovery might be prohibited for use with AI.
--   A web browser might allow all third-party cookies to be shared where the
-    cookie is labelled and Content Security Policies (CSPs) allow provided
-    labels. Rather than restricting third-party cookies they could provide a
-    report for their users of the legal basis used over all interactions over a
-    period of time and provide the user the option to disallow specific legal
-    basis.
--   As users become educated about the possibilities a web browser’s user could
-    configure their `tui` values allow and disallow lists to be synchronized
-    from other sources including their trusted data protection authority or a
-    well-known entity that curates allow and disallow lists. Web browser vendors
-    would not need to do this on behalf of their users and thus avoid an
-    anti-competitive conflict of interest. Indeed, the same rules would apply to
-    their own data sharing within the web browser and attract the same level of
-    transparency.
--   An entity receiving data via OpenRTB could automatically discard any data
-    that is not labelled with a value that their Data Protection Officer (DPO)
-    has approved. The DPOs workload could be managed based on the frequency of
-    which new labels appear.
--   A trade body or law firm might maintain a list of allowed and disallowed
-    values for their members or customers aiding DPO curation of these lists.
--   Insurance companies might publish lists that attract lower premiums for data
-    protection insurance when applied.
+- An AI vendor’s crawler would only retrieve content that was associated with a
+  pre-authorized `tdl` document. If allowed the `tdl` document would then be
+  attached to all onwards uses of that content and verified before using the
+  content. For example; the same content with a `tdl` document that allows for
+  use with discovery might be prohibited for use with AI.
+- A web browser might allow all third-party cookies to be shared where the
+  cookie is labelled and Content Security Policies (CSPs) allow provided labels.
+  Rather than restricting third-party cookies they could provide a report for
+  their users of the legal basis used over all interactions over a period of
+  time and provide the user the option to disallow specific legal basis.
+- As users become educated about the possibilities a web browser’s user could
+  configure their `tdl` values allow and disallow lists to be synchronized from
+  other sources including their trusted data protection authority or a
+  well-known entity that curates allow and disallow lists. Web browser vendors
+  would not need to do this on behalf of their users and thus avoid an
+  anti-competitive conflict of interest. Indeed, the same rules would apply to
+  their own data sharing within the web browser and attract the same level of
+  transparency.
+- An entity receiving data via OpenRTB could automatically discard any data that
+  is not labelled with a value that their Data Protection Officer (DPO) has
+  approved. The DPOs workload could be managed based on the frequency of which
+  new labels appear.
+- A trade body or law firm might maintain a list of allowed and disallowed
+  values for their members or customers aiding DPO curation of these lists.
+- Insurance companies might publish lists that attract lower premiums for data
+  protection insurance when applied.
 
 ### Web Browser
 
@@ -650,15 +660,15 @@ fonts, styles, images, and more.
 
 Keys are separated by semi-colons`;`.
 
-The proposal requires adding an additional key named `tui-src` to the CSP which
+The proposal requires adding an additional key named `tdl-src` to the CSP which
 is a simplified implementation of the keys used for JavaScript or any other
-content type. The values following `tui-src` are the values accepted and
+content type. The values following `tdl-src` are the values accepted and
 complied with by the domain owner.
 
 A simple example with two values follows.
 
 ```text
-content-security-policy: tui-src https://ex.io/eu-ads-v1.html
+content-security-policy: tdl-src https://ex.io/eu-ads-v1.html
 https://ex.io/eu-meta-v3.html; script-src 'strict-dynamic'
 'nonce-QnDzo0LUa5zAu6ZpdTcHHwOuuRMjt1xGRukWMmc72UhAKUbZAx' 'self'
 'report-sample' 'unsafe-inline' assets.wearehearken.eu cdn.syndication.twimg.com
@@ -668,7 +678,7 @@ connect.facebook.net c.files.bbci.co.uk…
 #### Access
 
 The web browser will only retrieve and display the content where one or more of
-the `tui-src` values has been agreed to by the user of the web browser. There
+the `tdl-src` values has been agreed to by the user of the web browser. There
 will need to be a period of transition where web browsers do not strictly
 enforce this requirement.
 
@@ -679,19 +689,19 @@ shown in the address bar of the web browser no additional checks of the CSP are
 required.
 
 Where the domain associated with the storage operation is different the CSP of
-the domain shown in the address bar MUST include the `tui` label associated with
-the write operation if the write operation is be successful. The `tui` label is
+the domain shown in the address bar MUST include the `tdl` label associated with
+the write operation if the write operation is be successful. The `tdl` label is
 not included the address bar domain’s CSP then the write operation fails.
 
-This feature ensures that the address bar domain operator controls allowed `tui`
+This feature ensures that the address bar domain operator controls allowed `tdl`
 label for not just themselves but their suppliers.
 
 #### Retrieval
 
 When a request is received by a web browser and there is an opportunity to
 provide cookies or other data in response a check MUST be performed against the
-CSP associated with the request and only those labels that relate to `tui`
-labels that are contained in the `tui` list of the CSP can be provided in
+CSP associated with the request and only those labels that relate to `tdl`
+labels that are contained in the `tdl` list of the CSP can be provided in
 response.
 
 Consider a cookie that is written using the following syntax in an HTTP header.
@@ -699,61 +709,61 @@ Consider a cookie that is written using the following syntax in an HTTP header.
 ```text
 Set-Cookie: device={ ... } ; Expires=Thu, 21 Oct 2025 07:28:00 GMT; Secure;
 HttpOnly;
-TUI=https://ex.io/eu-ads-v1.html
+TDL=https://ex.io/eu-ads-v1.html
 ```
 
 The value of that cookie MUST only be provided where the requestor’s CSP
-indicates that they accept the `tui` label `https://ex.io/eu-ads-v1.html`. The
+indicates that they accept the `tdl` label `https://ex.io/eu-ads-v1.html`. The
 following is an example of such a CSP.
 
 ```text
-content-security-policy: tui-src https://ex.io/eu-ads-v1.html;
+content-security-policy: tdl-src https://ex.io/eu-ads-v1.html;
 ```
 
-If the CSP does not contain a matching `tui` label, then no information will be
-provided. As such the requestor will need to know the `tui` label used when
+If the CSP does not contain a matching `tdl` label, then no information will be
+provided. As such the requestor will need to know the `tdl` label used when
 writing the key before it can retrieve the value.
 
 The concepts apply to all methods of retrieving data including cookies and API
-calls. As such existing interfaces do not need to be modified as the `tui`
+calls. As such existing interfaces do not need to be modified as the `tdl`
 labels are communicated via established complementary channels. Only the methods
 associated with writing data within web browsers need to be modified.
 
 Optionally the web browser can record the identity of the requesting entity, the
-`tui` labels, and whether the data was returned or not. Using these labels web
+`tdl` labels, and whether the data was returned or not. Using these labels web
 browser vendors can provide reports to people, or in aggregate across consenting
 people, concerning the legal basis under which data is stored and provided and
 to whom.
 
 ### Examples
 
-Consider three `tui` labels L1, L2, and L3 and three actor domains A, B, and C.
+Consider three `tdl` labels L1, L2, and L3 and three actor domains A, B, and C.
 
--   A writes the value Y to key X with `tui` L1.
--   B then seeks to read key X from A with `tui` L1. Y is returned.
--   C then seeks to read key X from A with `tui` L2. The operation is disallowed
-    and Y is not returned.
--   A then seeks to read key X from A with `tui` L3 having dropped the use of
-    L1. The operation is disallowed and Y is not returned. This is because the
-    `tui` value does not match L1 provided when A wrote key X.
+- A writes the value Y to key X with `tdl` L1.
+- B then seeks to read key X from A with `tdl` L1. Y is returned.
+- C then seeks to read key X from A with `tdl` L2. The operation is disallowed
+  and Y is not returned.
+- A then seeks to read key X from A with `tdl` L3 having dropped the use of L1.
+  The operation is disallowed and Y is not returned. This is because the `tdl`
+  value does not match L1 provided when A wrote key X.
 
 Any changes to restrict third-party cookies and other data exchanges MUST not be
-applied when `tui` values are provided.
+applied when `tdl` values are provided.
 
 Now consider A and B using C to provide supplier resources.
 
--   A’s CSP includes L1 and L2 but not L3.
--   B’s CSP includes L1 and L3 but not L2.
--   C’s CSP includes L1, L2, and L3.
--   C operating as a supplier resource for A writes the value Y to key X with
-    `tui` L1. The operation succeeds.
--   C operating as a supplier resource for B reads the key X. The operation
-    succeeds.
--   C operating as a supplier resource for A writes the value Y to key W with
-    `tui` L2. The operation succeeds.
--   C operating as a supplier resource for B reads the key W. The operation
-    fails because B does not permit operations with L2 which is the `tui` value
-    used to write key W.
+- A’s CSP includes L1 and L2 but not L3.
+- B’s CSP includes L1 and L3 but not L2.
+- C’s CSP includes L1, L2, and L3.
+- C operating as a supplier resource for A writes the value Y to key X with
+  `tdl` L1. The operation succeeds.
+- C operating as a supplier resource for B reads the key X. The operation
+  succeeds.
+- C operating as a supplier resource for A writes the value Y to key W with
+  `tdl` L2. The operation succeeds.
+- C operating as a supplier resource for B reads the key W. The operation fails
+  because B does not permit operations with L2 which is the `tdl` value used to
+  write key W.
 
 ## Benefits
 
@@ -790,7 +800,7 @@ these legal basis then the publisher will know they will not be contributing to
 other publishers via their chosen suppliers.
 
 For example; a copyright holder might be comfortable making their data available
-only to human’s and not machines. By applying the `tui` label to both
+only to human’s and not machines. By applying the `tdl` label to both
 `robots.txt` and either the CSP or `html` elements they can signal this
 restriction preventing web browsers being used by AI vendors as a way of
 obtaining their copyright protected content.
@@ -820,7 +830,7 @@ a matter of competition among implementors.
 The problems of people consenting and providing proof that consent was given.
 The proposal might evolve to do so in a future iteration via the addition of
 cryptographic proofs similar to the digital signatures available in email or
-tokens that include the `tui` document, a unique identifier for the content, the
+tokens that include the `tdl` document, a unique identifier for the content, the
 identifies of the sending and receiving parties, and the date and time of the
 trans
 
@@ -839,41 +849,39 @@ matter of competition once a method of labelling data is established.
 Using data labels to label content such that digital rights holders can express
 the basis under which the content is provided.
 
-## TUI guidance
+## TDL guidance
 
 Users of this proposal MUST consider the following.
 
--   TUI values must be unchanging once published.
+- TDL values must be unchanging once published.
 
 Users of this proposal SHOULD consider the following if their documents are to
 be widely used.
 
--   TUI values should be short, and publicly available to reduce additional data
-    overhead.
--   To avoid administrative complexity in practice organizations will benefit
-    from working together to agree on common terms documents for common
-    purposes.
--   Applying terms documents to groups of related data is preferable for
-    efficiency than creating legal basis documents for each individual data
-    item. For example, groups of data like those describing the location or
-    characteristics of a device are preferable to ones that describe each
-    individual aspect of that data.
+- TDL values should be short, and publicly available to reduce additional data
+  overhead.
+- To avoid administrative complexity in practice organizations will benefit from
+  working together to agree on common terms documents for common purposes.
+- Applying terms documents to groups of related data is preferable for
+  efficiency than creating legal basis documents for each individual data item.
+  For example, groups of data like those describing the location or
+  characteristics of a device are preferable to ones that describe each
+  individual aspect of that data.
 
 Users of this proposal MAY wish to consider the following.
 
--   When interacting with people to incorporate TUIs into their user
-    documentation in addition to information that describes the data stored on
-    the device. For example; updating privacy policies to not only list cookies,
-    but also data use beyond the web browser.
--   When not interacting with people, to publish the TUIs that they share or use
-    data under such that they are easily inspectable by other market
-    participants.
--   Seek certification of terms documents from relevant authorities such as the
-    Information Commissioner’s Office (ICO) that operate such certification
-    schemes. Such certification schemes are not within the scope of this
-    proposal. It is likely such certification activities would be carried out by
-    Data Protection Officers and not the engineers that implement support for
-    the TUI signal.
+- When interacting with people to incorporate TDLs into their user documentation
+  in addition to information that describes the data stored on the device. For
+  example; updating privacy policies to not only list cookies, but also data use
+  beyond the web browser.
+- When not interacting with people, to publish the TDLs that they share or use
+  data under such that they are easily inspectable by other market participants.
+- Seek certification of terms documents from relevant authorities such as the
+  Information Commissioner’s Office (ICO) that operate such certification
+  schemes. Such certification schemes are not within the scope of this proposal.
+  It is likely such certification activities would be carried out by Data
+  Protection Officers and not the engineers that implement support for the TDL
+  signal.
 
 ## Conclusion
 
@@ -909,10 +917,10 @@ they can use organizational measures to restrict and monitor for abuse.
 The following technical standards need to be modified and implemented for this
 proposal to be realized.
 
-1.  [OpenRTB](../../../AppData/Roaming/Microsoft/Word/OpenRTB.md)
-2.  [HTTP Cookies](../../../AppData/Roaming/Microsoft/Word/IETF-HTTP.md)
-3.  [Content Security Policy 2](../../../AppData/Roaming/Microsoft/Word/CSP.md)
-4.  [Robots.txt](../../../AppData/Roaming/Microsoft/Word/IETF-Robots.md)
+1. [OpenRTB](../../../AppData/Roaming/Microsoft/Word/OpenRTB.md)
+2. [HTTP Cookies](../../../AppData/Roaming/Microsoft/Word/IETF-HTTP.md)
+3. [Content Security Policy 2](../../../AppData/Roaming/Microsoft/Word/CSP.md)
+4. [Robots.txt](../../../AppData/Roaming/Microsoft/Word/IETF-Robots.md)
 
 Each of the links in the above list provides the proposed text changes to these
 documents.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ protections, protect content subject to copyright, and competition in digital
 markets.
 
 - [Proposal](Proposal.md) - A comprehensive explanation with examples
+- [Frequently Asked Questions](FAQs.md) - Common questions addressed
 - [Overview](Overview.pdf) - Introductory presentation (intended to be delivered
   by the authors which currently excludes the AI use case)
 - Dependent existing technical standards
@@ -25,4 +26,4 @@ markets.
   legislation has been implemented
 - [Appendix2](Appendix2.md) - Regulators or Government Officials: Statements of
   Support
-- [Appendix3](Appendix3.md) - Artificial Intelligence
+- [Appendix3](Appendix3.md) - Artificial Intelligence (to be completed)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,28 @@
 # Data Labels
 
-An open decentralized method of signaling the legal basis associated with the
-data collection, processing, use, and restrictions in cookies and OpenRTB.
+A decentralized method of attaching the terms underwhich data or copyright
+protected content is provided by a sender to a recipient such that the recipient
+can either accept or reject those terms unambiguously or an intermediary can
+facilitate data transfers based on knowledge of terms acceptable to both sender
+and recipient.
 
 ## Content
 
-This repository is a briefing concerning a practical implementation of data
-labels to improve data protections and competition in digital markets.
+This repository contains a practical implementation of a single data label
+concept consistently across many diverse technical standards to improve data
+protections, protect content subject to copyright, and competition in digital
+markets.
 
 - [Proposal](Proposal.md) - A comprehensive explanation with examples
-- [Overview](Overview.pdf) - Introductory presentation (intended to be delivered by the authors)
+- [Overview](Overview.pdf) - Introductory presentation (intended to be delivered
+  by the authors which currently excludes the AI use case)
 - Dependent existing technical standards
   - [HTTP State Management Mechanism](IETF-HTTP.md)
   - [Content Security Policy Level 2](CSP.md)
   - [OpenRTB](OpenRTB.md)
-- [Appendix1](Appendix1.md) - Countries where GDPR or ‘essentially equivalent’ legislation has been implemented
-- [Appendix2](Appendix2.md) - Regulators or Government Officials: Statements of Support
+  - [Robots.txt](IETF-Robots.md)
+- [Appendix1](Appendix1.md) - Countries where GDPR or ‘essentially equivalent’
+  legislation has been implemented
+- [Appendix2](Appendix2.md) - Regulators or Government Officials: Statements of
+  Support
+- [Appendix3](Appendix3.md) - Artificial Intelligence


### PR DESCRIPTION
## Changes

- Added a use case concerning licensing content protected by copyright for Artificial Intelligence (AI) purposes. General text modified to reflect this expansion.

- Replaced LBU (Legal Basis URL) with TDL (Terms Document Locator) as this is more general and suited to a wider range of use cases. The TDL is not restricted to being a Universal Resource Location (URL) and could be any unique identifier within a scheme agreed by the parties. A URL implementation remains the primary example.

- Modified the CSP changes to require the user agent to confirm that the user has accepted at least one of the TDL values. This is needed to prevent web browsers being used to obtain content protected by copyright via display to people.

- Added an FAQ document.